### PR TITLE
Integrate generic regalloc interface, and refactor backtracking regalloc and test-ISA to interact using it.

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -15,11 +15,12 @@ use std::{fs, io};
 
 use crate::data_structures::{
   mkBlockIx, mkInstIx, mkRangeFrag, mkRangeFragIx, mkRealRangeIx,
-  mkVirtualRangeIx, Block, BlockIx, Func, InstPoint, InstPoint_Def,
-  InstPoint_Use, Map, RangeFrag, RangeFragIx, RangeFragKind, RealRange,
-  RealRangeIx, Reg, Set, SortedRangeFragIxs, TypedIxVec, VirtualRange,
-  VirtualRangeIx,
+  mkVirtualRangeIx, BlockIx, InstPoint, InstPoint_Def, InstPoint_Use, Map,
+  RangeFrag, RangeFragIx, RangeFragKind, RealRange, RealRangeIx, Reg, Set,
+  SortedRangeFragIxs, TypedIxVec, VirtualRange, VirtualRangeIx,
 };
+
+use crate::tests::{Block, Func, Inst};
 
 //=============================================================================
 // Queues

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -19,8 +19,7 @@ use crate::data_structures::{
   RangeFrag, RangeFragIx, RangeFragKind, RealRange, RealRangeIx, Reg, Set,
   SortedRangeFragIxs, TypedIxVec, VirtualRange, VirtualRangeIx,
 };
-
-use crate::tests::{Block, Func, Inst};
+use crate::interface::Function;
 
 //=============================================================================
 // Queues
@@ -53,8 +52,8 @@ struct CFGInfo {
 
 impl CFGInfo {
   #[inline(never)]
-  fn create(func: &Func) -> Self {
-    let nBlocks = func.blocks.len();
+  fn create<F: Function>(func: &F) -> Self {
+    let nBlocks = func.blocks().len() as u32;
 
     // First calculate the succ map, since we can do that directly from
     // the Func.
@@ -63,9 +62,8 @@ impl CFGInfo {
     // the last instruction is a control flow transfer.  Hence the
     // following won't miss any edges.
     let mut succ_map = TypedIxVec::<BlockIx, Set<BlockIx>>::new();
-    for b in func.blocks.iter() {
-      let last_insn = &func.insns[b.start.plus(b.len).minus(1)];
-      let succs = last_insn.getTargets();
+    for b in func.blocks() {
+      let succs = func.block_succs(b);
       let mut bixSet = Set::<BlockIx>::empty();
       for bix in succs.iter() {
         bixSet.insert(*bix);
@@ -83,7 +81,7 @@ impl CFGInfo {
     }
 
     // Calculate dominators..
-    let dom_map = calc_dominators(&pred_map, func.entry.getBlockIx());
+    let dom_map = calc_dominators(&pred_map, func.entry_block());
 
     // Stay sane ..
     debug_assert!(pred_map.len() == nBlocks);
@@ -230,7 +228,7 @@ impl CFGInfo {
       &mut post_ord,
       &mut visited,
       &succ_map,
-      func.entry.getBlockIx(),
+      func.entry_block(),
     );
 
     debug_assert!(pre_ord.len() == post_ord.len());
@@ -268,9 +266,8 @@ fn calc_dominators(
   let mut dom_map = TypedIxVec::<BlockIx, Set<BlockIx>>::new();
   {
     let r: BlockIx = start;
-    let N: Set<BlockIx> = Set::from_vec(
-      (0..nBlocks as u32).map(|bixNo| mkBlockIx(bixNo)).collect(),
-    );
+    let N: Set<BlockIx> =
+      Set::from_vec((0..nBlocks).map(|bixNo| mkBlockIx(bixNo)).collect());
     let mut D: Set<BlockIx>;
     let mut T: Set<BlockIx>;
     let mut n: BlockIx;
@@ -278,7 +275,7 @@ fn calc_dominators(
     let mut change = true;
     dom_map.resize(nBlocks, Set::<BlockIx>::empty());
     dom_map[r] = Set::unit(r);
-    for ixnoN in 0..nBlocks as u32 {
+    for ixnoN in 0..nBlocks {
       let bixN = mkBlockIx(ixnoN);
       if bixN != r {
         dom_map[bixN] = N.clone();
@@ -312,117 +309,114 @@ fn calc_dominators(
 //=============================================================================
 // Computation of live-in and live-out sets
 
-impl Func {
-  // Returned TypedIxVecs contain one element per block
-  #[inline(never)]
-  fn calc_def_and_use(
-    &self,
-  ) -> (TypedIxVec<BlockIx, Set<Reg>>, TypedIxVec<BlockIx, Set<Reg>>) {
-    let mut def_sets = TypedIxVec::new();
-    let mut use_sets = TypedIxVec::new();
-    for b in self.blocks.iter() {
-      let mut def = Set::empty();
-      let mut uce = Set::empty();
-      for iix in b.start.dotdot(b.start.plus(b.len)) {
-        let insn = &self.insns[iix];
-        let (regs_d, regs_m, regs_u) = insn.get_reg_usage();
-        // Add to |uce|, any registers for which the first event
-        // in this block is a read.  Dealing with the "first event"
-        // constraint is a bit tricky.
-        for u in regs_u.iter().chain(regs_m.iter()) {
-          // |u| is used (either read or modified) by the
-          // instruction.  Whether or not we should consider it
-          // live-in for the block depends on whether it was been
-          // written earlier in the block.  We can determine that by
-          // checking whether it is already in the def set for the
-          // block.
-          if !def.contains(*u) {
-            uce.insert(*u);
-          }
-        }
-        // Now add to |def|, all registers written by the instruction.
-        // This is simpler.
-        // FIXME: isn't this just: defs union= (regs_d union regs_m) ?
-        // (Similar comment applies for the |uce| update too)
-        for d in regs_d.iter().chain(regs_m.iter()) {
-          def.insert(*d);
+// Returned TypedIxVecs contain one element per block
+#[inline(never)]
+fn calc_def_and_use<F: Function>(
+  f: &F,
+) -> (TypedIxVec<BlockIx, Set<Reg>>, TypedIxVec<BlockIx, Set<Reg>>) {
+  let mut def_sets = TypedIxVec::new();
+  let mut use_sets = TypedIxVec::new();
+  for b in f.blocks() {
+    let mut def = Set::empty();
+    let mut uce = Set::empty();
+    for iix in f.block_insns(b) {
+      let reg_usage = f.get_regs(f.get_insn(iix));
+      // Add to |uce|, any registers for which the first event
+      // in this block is a read.  Dealing with the "first event"
+      // constraint is a bit tricky.
+      for u in reg_usage.used.iter().chain(reg_usage.modified.iter()) {
+        // |u| is used (either read or modified) by the
+        // instruction.  Whether or not we should consider it
+        // live-in for the block depends on whether it was been
+        // written earlier in the block.  We can determine that by
+        // checking whether it is already in the def set for the
+        // block.
+        if !def.contains(*u) {
+          uce.insert(*u);
         }
       }
-      def_sets.push(def);
-      use_sets.push(uce);
+      // Now add to |def|, all registers written by the instruction.
+      // This is simpler.
+      // FIXME: isn't this just: defs union= (regs_d union regs_m) ?
+      // (Similar comment applies for the |uce| update too)
+      for d in reg_usage.defined.iter().chain(reg_usage.modified.iter()) {
+        def.insert(*d);
+      }
     }
-    (def_sets, use_sets)
+    def_sets.push(def);
+    use_sets.push(uce);
+  }
+  (def_sets, use_sets)
+}
+
+// Returned vectors contain one element per block
+#[inline(never)]
+fn calc_livein_and_liveout<F: Function>(
+  f: &F, def_sets_per_block: &TypedIxVec<BlockIx, Set<Reg>>,
+  use_sets_per_block: &TypedIxVec<BlockIx, Set<Reg>>, cfg_info: &CFGInfo,
+) -> (TypedIxVec<BlockIx, Set<Reg>>, TypedIxVec<BlockIx, Set<Reg>>) {
+  let nBlocks = f.blocks().len() as u32;
+  let empty = Set::<Reg>::empty();
+
+  let mut nEvals = 0;
+  let mut liveouts = TypedIxVec::<BlockIx, Set<Reg>>::new();
+  liveouts.resize(nBlocks, empty.clone());
+
+  // Initialise the work queue so as to do a reverse preorder traversal
+  // through the graph, after which blocks are re-evaluated on demand.
+  let mut workQ = Queue::<BlockIx>::new();
+  for i in 0..nBlocks {
+    // bixI travels in "reverse preorder"
+    let bixI = cfg_info.pre_ord[(nBlocks - 1 - i) as usize];
+    workQ.push_back(bixI);
   }
 
-  // Returned vectors contain one element per block
-  #[inline(never)]
-  fn calc_livein_and_liveout(
-    &self, def_sets_per_block: &TypedIxVec<BlockIx, Set<Reg>>,
-    use_sets_per_block: &TypedIxVec<BlockIx, Set<Reg>>, cfg_info: &CFGInfo,
-  ) -> (TypedIxVec<BlockIx, Set<Reg>>, TypedIxVec<BlockIx, Set<Reg>>) {
-    let nBlocks = self.blocks.len();
-    let empty = Set::<Reg>::empty();
-
-    let mut nEvals = 0;
-    let mut liveouts = TypedIxVec::<BlockIx, Set<Reg>>::new();
-    liveouts.resize(nBlocks, empty.clone());
-
-    // Initialise the work queue so as to do a reverse preorder traversal
-    // through the graph, after which blocks are re-evaluated on demand.
-    let mut workQ = Queue::<BlockIx>::new();
-    for i in 0..nBlocks {
-      // bixI travels in "reverse preorder"
-      let bixI = cfg_info.pre_ord[(nBlocks - 1 - i) as usize];
-      workQ.push_back(bixI);
+  while let Some(bixI) = workQ.pop_front() {
+    // Compute a new value for liveouts[bixI]
+    let mut set = Set::<Reg>::empty();
+    for bixJ in cfg_info.succ_map[bixI].iter() {
+      let mut liveinJ = liveouts[*bixJ].clone();
+      liveinJ.remove(&def_sets_per_block[*bixJ]);
+      liveinJ.union(&use_sets_per_block[*bixJ]);
+      set.union(&liveinJ);
     }
+    nEvals += 1;
 
-    while let Some(bixI) = workQ.pop_front() {
-      // Compute a new value for liveouts[bixI]
-      let mut set = Set::<Reg>::empty();
-      for bixJ in cfg_info.succ_map[bixI].iter() {
-        let mut liveinJ = liveouts[*bixJ].clone();
-        liveinJ.remove(&def_sets_per_block[*bixJ]);
-        liveinJ.union(&use_sets_per_block[*bixJ]);
-        set.union(&liveinJ);
-      }
-      nEvals += 1;
-
-      if !set.equals(&liveouts[bixI]) {
-        liveouts[bixI] = set;
-        // Add |bixI|'s predecessors to the work queue, since their
-        // liveout values might be affected.
-        for bixJ in cfg_info.pred_map[bixI].iter() {
-          workQ.push_back(*bixJ);
-        }
+    if !set.equals(&liveouts[bixI]) {
+      liveouts[bixI] = set;
+      // Add |bixI|'s predecessors to the work queue, since their
+      // liveout values might be affected.
+      for bixJ in cfg_info.pred_map[bixI].iter() {
+        workQ.push_back(*bixJ);
       }
     }
-
-    // The liveout values are done, but we need to compute the liveins
-    // too.
-    let mut liveins = TypedIxVec::<BlockIx, Set<Reg>>::new();
-    liveins.resize(nBlocks, empty.clone());
-    for bixI in mkBlockIx(0).dotdot(mkBlockIx(nBlocks)) {
-      let mut liveinI = liveouts[bixI].clone();
-      liveinI.remove(&def_sets_per_block[bixI]);
-      liveinI.union(&use_sets_per_block[bixI]);
-      liveins[bixI] = liveinI;
-    }
-
-    if false {
-      let mut sum_card_LI = 0;
-      let mut sum_card_LO = 0;
-      for bix in mkBlockIx(0).dotdot(mkBlockIx(nBlocks)) {
-        sum_card_LI += liveins[bix].card();
-        sum_card_LO += liveouts[bix].card();
-      }
-      println!(
-        "QQQQ calc_LI/LO: nEvals {}, tot LI {}, tot LO {}",
-        nEvals, sum_card_LI, sum_card_LO
-      );
-    }
-
-    (liveins, liveouts)
   }
+
+  // The liveout values are done, but we need to compute the liveins
+  // too.
+  let mut liveins = TypedIxVec::<BlockIx, Set<Reg>>::new();
+  liveins.resize(nBlocks, empty.clone());
+  for bixI in mkBlockIx(0).dotdot(mkBlockIx(nBlocks)) {
+    let mut liveinI = liveouts[bixI].clone();
+    liveinI.remove(&def_sets_per_block[bixI]);
+    liveinI.union(&use_sets_per_block[bixI]);
+    liveins[bixI] = liveinI;
+  }
+
+  if false {
+    let mut sum_card_LI = 0;
+    let mut sum_card_LO = 0;
+    for bix in mkBlockIx(0).dotdot(mkBlockIx(nBlocks)) {
+      sum_card_LI += liveins[bix].card();
+      sum_card_LO += liveouts[bix].card();
+    }
+    println!(
+      "QQQQ calc_LI/LO: nEvals {}, tot LI {}, tot LO {}",
+      nEvals, sum_card_LI, sum_card_LO
+    );
+  }
+
+  (liveins, liveouts)
 }
 
 //=============================================================================
@@ -432,275 +426,270 @@ impl Func {
 // handle (1) live-in and live-out Regs, (2) dead writes, and (3) instructions
 // that modify registers rather than merely reading or writing them.
 
-impl Func {
-  // Calculate all the RangeFrags for |bix|.  Add them to |outFEnv| and add
-  // to |outMap|, the associated RangeFragIxs, segregated by Reg.  |bix|,
-  // |livein| and |liveout| are expected to be valid in the context of the
-  // Func |self| (duh!)
-  fn get_RangeFrags_for_block(
-    &self, bix: BlockIx, livein: &Set<Reg>, liveout: &Set<Reg>,
-    outMap: &mut Map<Reg, Vec<RangeFragIx>>,
-    outFEnv: &mut TypedIxVec<RangeFragIx, RangeFrag>,
-  ) {
-    //println!("QQQQ --- block {}", bix.show());
-    // BEGIN ProtoRangeFrag
-    // A ProtoRangeFrag carries information about a write .. read range,
-    // within a Block, which we will later turn into a fully-fledged
-    // RangeFrag.  It basically records the first and last-known
-    // InstPoints for appearances of a Reg.
-    //
-    // ProtoRangeFrag also keeps count of the number of appearances of
-    // the Reg to which it pertains, using |uses|.  The counts get rolled
-    // into the resulting RangeFrags, and later are used to calculate
-    // spill costs.
-    //
-    // The running state of this function is a map from Reg to
-    // ProtoRangeFrag.  Only Regs that actually appear in the Block (or are
-    // live-in to it) are mapped.  This has the advantage of economy, since
-    // most Regs will not appear in (or be live-in to) most Blocks.
-    //
-    struct ProtoRangeFrag {
-      // The InstPoint in this Block at which the associated Reg most
-      // recently became live (when moving forwards though the Block).
-      // If this value is the first InstPoint for the Block (the U point
-      // for the Block's lowest InstIx), that indicates the associated
-      // Reg is live-in to the Block.
-      first: InstPoint,
+// Calculate all the RangeFrags for |bix|.  Add them to |outFEnv| and add
+// to |outMap|, the associated RangeFragIxs, segregated by Reg.  |bix|,
+// |livein| and |liveout| are expected to be valid in the context of the
+// Func |self| (duh!)
+fn get_RangeFrags_for_block<F: Function>(
+  f: &F, bix: BlockIx, livein: &Set<Reg>, liveout: &Set<Reg>,
+  outMap: &mut Map<Reg, Vec<RangeFragIx>>,
+  outFEnv: &mut TypedIxVec<RangeFragIx, RangeFrag>,
+) {
+  //println!("QQQQ --- block {}", bix.show());
+  // BEGIN ProtoRangeFrag
+  // A ProtoRangeFrag carries information about a write .. read range,
+  // within a Block, which we will later turn into a fully-fledged
+  // RangeFrag.  It basically records the first and last-known
+  // InstPoints for appearances of a Reg.
+  //
+  // ProtoRangeFrag also keeps count of the number of appearances of
+  // the Reg to which it pertains, using |uses|.  The counts get rolled
+  // into the resulting RangeFrags, and later are used to calculate
+  // spill costs.
+  //
+  // The running state of this function is a map from Reg to
+  // ProtoRangeFrag.  Only Regs that actually appear in the Block (or are
+  // live-in to it) are mapped.  This has the advantage of economy, since
+  // most Regs will not appear in (or be live-in to) most Blocks.
+  //
+  struct ProtoRangeFrag {
+    // The InstPoint in this Block at which the associated Reg most
+    // recently became live (when moving forwards though the Block).
+    // If this value is the first InstPoint for the Block (the U point
+    // for the Block's lowest InstIx), that indicates the associated
+    // Reg is live-in to the Block.
+    first: InstPoint,
 
-      // And this is the InstPoint which is the end point (most recently
-      // observed read, in general) for the current RangeFrag under
-      // construction.  In general we will move |last| forwards as we
-      // discover reads of the associated Reg.  If this is the last
-      // InstPoint for the Block (the D point for the Block's highest
-      // InstInx), that indicates that the associated reg is live-out
-      // from the Block.
-      last: InstPoint,
+    // And this is the InstPoint which is the end point (most recently
+    // observed read, in general) for the current RangeFrag under
+    // construction.  In general we will move |last| forwards as we
+    // discover reads of the associated Reg.  If this is the last
+    // InstPoint for the Block (the D point for the Block's highest
+    // InstInx), that indicates that the associated reg is live-out
+    // from the Block.
+    last: InstPoint,
 
-      // Number of mentions of the associated Reg in this ProtoRangeFrag.
-      uses: u16,
+    // Number of mentions of the associated Reg in this ProtoRangeFrag.
+    uses: u16,
+  }
+  impl fmt::Debug for ProtoRangeFrag {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+      write!(fmt, "{:?}x {:?} - {:?}", self.uses, self.first, self.last)
     }
-    impl fmt::Debug for ProtoRangeFrag {
-      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{:?}x {:?} - {:?}", self.uses, self.first, self.last)
-      }
+  }
+  // END ProtoRangeFrag
+
+  fn plus1(n: u16) -> u16 {
+    if n == 0xFFFFu16 {
+      n
+    } else {
+      n + 1
     }
-    // END ProtoRangeFrag
+  }
 
-    fn plus1(n: u16) -> u16 {
-      if n == 0xFFFFu16 {
-        n
-      } else {
-        n + 1
-      }
-    }
+  // Some handy constants.
+  debug_assert!(f.block_insns(bix).len() >= 1);
+  let first_iix_in_block = f.block_insns(bix).first();
+  let last_iix_in_block = f.block_insns(bix).last();
+  let first_pt_in_block = InstPoint_Use(first_iix_in_block);
+  let last_pt_in_block = InstPoint_Def(last_iix_in_block);
 
-    // Some handy constants.
-    let blocks = &self.blocks;
-    let block = &blocks[bix];
-    debug_assert!(block.len >= 1);
-    let first_iix_in_block = block.start.get();
-    let last_iix_in_block = first_iix_in_block + block.len - 1;
-    let first_pt_in_block = InstPoint_Use(mkInstIx(first_iix_in_block));
-    let last_pt_in_block = InstPoint_Def(mkInstIx(last_iix_in_block));
+  // The running state.
+  let mut state = Map::<Reg, ProtoRangeFrag>::default();
 
-    // The running state.
-    let mut state = Map::<Reg, ProtoRangeFrag>::default();
+  // The generated RangeFrags are initially are dumped in here.  We
+  // group them by Reg at the end of this function.
+  let mut tmpResultVec = Vec::<(Reg, RangeFrag)>::new();
 
-    // The generated RangeFrags are initially are dumped in here.  We
-    // group them by Reg at the end of this function.
-    let mut tmpResultVec = Vec::<(Reg, RangeFrag)>::new();
+  // First, set up |state| as if all of |livein| had been written just
+  // prior to the block.
+  for r in livein.iter() {
+    state.insert(
+      *r,
+      ProtoRangeFrag {
+        uses: 0,
+        first: first_pt_in_block,
+        last: first_pt_in_block,
+      },
+    );
+  }
 
-    // First, set up |state| as if all of |livein| had been written just
-    // prior to the block.
-    for r in livein.iter() {
-      state.insert(
-        *r,
-        ProtoRangeFrag {
-          uses: 0,
-          first: first_pt_in_block,
-          last: first_pt_in_block,
-        },
-      );
-    }
+  // Now visit each instruction in turn, examining first the registers
+  // it reads, then those it modifies, and finally those it writes.
+  for iix in f.block_insns(bix) {
+    //fn id<'a>(x: Vec::<(&'a Reg, &'a ProtoRangeFrag)>)
+    //          -> Vec::<(&'a Reg, &'a ProtoRangeFrag)> { x }
+    //println!("");
+    //println!("QQQQ state before {}",
+    //         id(state.iter().collect()).show());
+    //println!("QQQQ insn {} {}", iix.show(), insn.show());
 
-    // Now visit each instruction in turn, examining first the registers
-    // it reads, then those it modifies, and finally those it writes.
-    for iix in block.start.dotdot(block.start.plus(block.len)) {
-      let insn = &self.insns[iix];
+    let reg_usage = f.get_regs(f.get_insn(iix));
 
-      //fn id<'a>(x: Vec::<(&'a Reg, &'a ProtoRangeFrag)>)
-      //          -> Vec::<(&'a Reg, &'a ProtoRangeFrag)> { x }
-      //println!("");
-      //println!("QQQQ state before {}",
-      //         id(state.iter().collect()).show());
-      //println!("QQQQ insn {} {}", iix.show(), insn.show());
-
-      let (regs_d, regs_m, regs_u) = insn.get_reg_usage();
-
-      // Examine reads.  This is pretty simple.  They simply extend an
-      // existing ProtoRangeFrag to the U point of the reading insn.
-      for r in regs_u.iter() {
-        let new_pf: ProtoRangeFrag;
-        match state.get(r) {
-          // First event for |r| is a read, but it's not listed in
-          // |livein|, since otherwise |state| would have an entry
-          // for it.
-          None => {
-            panic!("get_RangeFrags_for_block: fail #1");
-          }
-          // This the first or subsequent read after a write.  Note
-          // that the "write" can be either a real write, or due to
-          // the fact that |r| is listed in |livein|.  We don't care
-          // here.
-          Some(ProtoRangeFrag { uses, first, last }) => {
-            let new_last = InstPoint_Use(iix);
-            debug_assert!(last <= &new_last);
-            new_pf = ProtoRangeFrag {
-              uses: plus1(*uses),
-              first: *first,
-              last: new_last,
-            };
-          }
-        }
-        state.insert(*r, new_pf);
-      }
-
-      // Examine modifies.  These are handled almost identically to
-      // reads, except that they extend an existing ProtoRangeFrag down to
-      // the D point of the modifying insn.
-      for r in regs_m.iter() {
-        let new_pf: ProtoRangeFrag;
-        match state.get(r) {
-          // First event for |r| is a read (really, since this insn
-          // modifies |r|), but it's not listed in |livein|, since
-          // otherwise |state| would have an entry for it.
-          None => {
-            panic!("get_RangeFrags_for_block: fail #2");
-          }
-          // This the first or subsequent modify after a write.
-          Some(ProtoRangeFrag { uses, first, last }) => {
-            let new_last = InstPoint_Def(iix);
-            debug_assert!(last <= &new_last);
-            new_pf = ProtoRangeFrag {
-              uses: plus1(*uses),
-              first: *first,
-              last: new_last,
-            };
-          }
-        }
-        state.insert(*r, new_pf);
-      }
-
-      // Examine writes (but not writes implied by modifies).  The
-      // general idea is that a write causes us to terminate the
-      // existing ProtoRangeFrag, if any, add it to |tmpResultVec|,
-      // and start a new frag.
-      for r in regs_d.iter() {
-        let new_pf: ProtoRangeFrag;
-        match state.get(r) {
-          // First mention of a Reg we've never heard of before.
-          // Start a new ProtoRangeFrag for it and keep going.
-          None => {
-            let new_pt = InstPoint_Def(iix);
-            new_pf = ProtoRangeFrag { uses: 1, first: new_pt, last: new_pt };
-          }
-          // There's already a ProtoRangeFrag for |r|.  This write
-          // will start a new one, so flush the existing one and
-          // note this write.
-          Some(ProtoRangeFrag { uses, first, last }) => {
-            if first == last {
-              debug_assert!(*uses == 1);
-            }
-            let frag = mkRangeFrag(blocks, bix, *first, *last, *uses);
-            tmpResultVec.push((*r, frag));
-            let new_pt = InstPoint_Def(iix);
-            new_pf = ProtoRangeFrag { uses: 1, first: new_pt, last: new_pt };
-          }
-        }
-        state.insert(*r, new_pf);
-      }
-      //println!("QQQQ state after  {}",
-      //         id(state.iter().collect()).show());
-    }
-
-    // We are at the end of the block.  We still have to deal with
-    // live-out Regs.  We must also deal with ProtoRangeFrags in |state|
-    // that are for registers not listed as live-out.
-
-    // Deal with live-out Regs.  Treat each one as if it is read just
-    // after the block.
-    for r in liveout.iter() {
-      //println!("QQQQ post: liveout:  {}", r.show());
+    // Examine reads.  This is pretty simple.  They simply extend an
+    // existing ProtoRangeFrag to the U point of the reading insn.
+    for r in reg_usage.used.iter() {
+      let new_pf: ProtoRangeFrag;
       match state.get(r) {
-        // This can't happen.  |r| is in |liveout|, but this implies
-        // that it is neither defined in the block nor present in
-        // |livein|.
+        // First event for |r| is a read, but it's not listed in
+        // |livein|, since otherwise |state| would have an entry
+        // for it.
         None => {
-          panic!("get_RangeFrags_for_block: fail #3");
+          panic!("get_RangeFrags_for_block: fail #1");
         }
-        // |r| is written (or modified), either literally or by virtue
-        // of being present in |livein|, and may or may not
-        // subsequently be read -- we don't care, because it must be
-        // read "after" the block.  Create a |LiveOut| or |Thru| frag
-        // accordingly.
-        Some(ProtoRangeFrag { uses, first, last: _ }) => {
-          let frag = mkRangeFrag(blocks, bix, *first, last_pt_in_block, *uses);
+        // This the first or subsequent read after a write.  Note
+        // that the "write" can be either a real write, or due to
+        // the fact that |r| is listed in |livein|.  We don't care
+        // here.
+        Some(ProtoRangeFrag { uses, first, last }) => {
+          let new_last = InstPoint_Use(iix);
+          debug_assert!(last <= &new_last);
+          new_pf = ProtoRangeFrag {
+            uses: plus1(*uses),
+            first: *first,
+            last: new_last,
+          };
+        }
+      }
+      state.insert(*r, new_pf);
+    }
+
+    // Examine modifies.  These are handled almost identically to
+    // reads, except that they extend an existing ProtoRangeFrag down to
+    // the D point of the modifying insn.
+    for r in reg_usage.modified.iter() {
+      let new_pf: ProtoRangeFrag;
+      match state.get(r) {
+        // First event for |r| is a read (really, since this insn
+        // modifies |r|), but it's not listed in |livein|, since
+        // otherwise |state| would have an entry for it.
+        None => {
+          panic!("get_RangeFrags_for_block: fail #2");
+        }
+        // This the first or subsequent modify after a write.
+        Some(ProtoRangeFrag { uses, first, last }) => {
+          let new_last = InstPoint_Def(iix);
+          debug_assert!(last <= &new_last);
+          new_pf = ProtoRangeFrag {
+            uses: plus1(*uses),
+            first: *first,
+            last: new_last,
+          };
+        }
+      }
+      state.insert(*r, new_pf);
+    }
+
+    // Examine writes (but not writes implied by modifies).  The
+    // general idea is that a write causes us to terminate the
+    // existing ProtoRangeFrag, if any, add it to |tmpResultVec|,
+    // and start a new frag.
+    for r in reg_usage.defined.iter() {
+      let new_pf: ProtoRangeFrag;
+      match state.get(r) {
+        // First mention of a Reg we've never heard of before.
+        // Start a new ProtoRangeFrag for it and keep going.
+        None => {
+          let new_pt = InstPoint_Def(iix);
+          new_pf = ProtoRangeFrag { uses: 1, first: new_pt, last: new_pt };
+        }
+        // There's already a ProtoRangeFrag for |r|.  This write
+        // will start a new one, so flush the existing one and
+        // note this write.
+        Some(ProtoRangeFrag { uses, first, last }) => {
+          if first == last {
+            debug_assert!(*uses == 1);
+          }
+          let frag = mkRangeFrag(f, bix, *first, *last, *uses);
           tmpResultVec.push((*r, frag));
+          let new_pt = InstPoint_Def(iix);
+          new_pf = ProtoRangeFrag { uses: 1, first: new_pt, last: new_pt };
         }
       }
-      // Remove the entry from |state| so that the following loop
-      // doesn't process it again.
-      state.remove(r);
+      state.insert(*r, new_pf);
     }
+    //println!("QQQQ state after  {}",
+    //         id(state.iter().collect()).show());
+  }
 
-    // Finally, round up any remaining ProtoRangeFrags left in |state|.
-    for (r, pf) in state.iter() {
-      //println!("QQQQ post: leftover: {} {}", r.show(), pf.show());
-      if pf.first == pf.last {
-        debug_assert!(pf.uses == 1);
+  // We are at the end of the block.  We still have to deal with
+  // live-out Regs.  We must also deal with ProtoRangeFrags in |state|
+  // that are for registers not listed as live-out.
+
+  // Deal with live-out Regs.  Treat each one as if it is read just
+  // after the block.
+  for r in liveout.iter() {
+    //println!("QQQQ post: liveout:  {}", r.show());
+    match state.get(r) {
+      // This can't happen.  |r| is in |liveout|, but this implies
+      // that it is neither defined in the block nor present in
+      // |livein|.
+      None => {
+        panic!("get_RangeFrags_for_block: fail #3");
       }
-      let frag = mkRangeFrag(blocks, bix, pf.first, pf.last, pf.uses);
-      //println!("QQQQ post: leftover: {}", (r,frag).show());
-      tmpResultVec.push((*r, frag));
+      // |r| is written (or modified), either literally or by virtue
+      // of being present in |livein|, and may or may not
+      // subsequently be read -- we don't care, because it must be
+      // read "after" the block.  Create a |LiveOut| or |Thru| frag
+      // accordingly.
+      Some(ProtoRangeFrag { uses, first, last: _ }) => {
+        let frag = mkRangeFrag(f, bix, *first, last_pt_in_block, *uses);
+        tmpResultVec.push((*r, frag));
+      }
     }
+    // Remove the entry from |state| so that the following loop
+    // doesn't process it again.
+    state.remove(r);
+  }
 
-    // Copy the entries in |tmpResultVec| into |outMap| and |outVec|.
-    // TODO: do this as we go along, so as to avoid the use of a temporary
-    // vector.
-    for (r, frag) in tmpResultVec {
-      outFEnv.push(frag);
-      let new_fix = mkRangeFragIx(outFEnv.len() as u32 - 1);
-      match outMap.get_mut(&r) {
-        None => {
-          outMap.insert(r, vec![new_fix]);
-        }
-        Some(fragVec) => {
-          fragVec.push(new_fix);
-        }
+  // Finally, round up any remaining ProtoRangeFrags left in |state|.
+  for (r, pf) in state.iter() {
+    //println!("QQQQ post: leftover: {} {}", r.show(), pf.show());
+    if pf.first == pf.last {
+      debug_assert!(pf.uses == 1);
+    }
+    let frag = mkRangeFrag(f, bix, pf.first, pf.last, pf.uses);
+    //println!("QQQQ post: leftover: {}", (r,frag).show());
+    tmpResultVec.push((*r, frag));
+  }
+
+  // Copy the entries in |tmpResultVec| into |outMap| and |outVec|.
+  // TODO: do this as we go along, so as to avoid the use of a temporary
+  // vector.
+  for (r, frag) in tmpResultVec {
+    outFEnv.push(frag);
+    let new_fix = mkRangeFragIx(outFEnv.len() as u32 - 1);
+    match outMap.get_mut(&r) {
+      None => {
+        outMap.insert(r, vec![new_fix]);
+      }
+      Some(fragVec) => {
+        fragVec.push(new_fix);
       }
     }
   }
+}
 
-  #[inline(never)]
-  fn get_RangeFrags(
-    &self, livein_sets_per_block: &TypedIxVec<BlockIx, Set<Reg>>,
-    liveout_sets_per_block: &TypedIxVec<BlockIx, Set<Reg>>,
-  ) -> (Map<Reg, Vec<RangeFragIx>>, TypedIxVec<RangeFragIx, RangeFrag>) {
-    debug_assert!(livein_sets_per_block.len() == self.blocks.len());
-    debug_assert!(liveout_sets_per_block.len() == self.blocks.len());
-    let mut resMap = Map::<Reg, Vec<RangeFragIx>>::default();
-    let mut resFEnv = TypedIxVec::<RangeFragIx, RangeFrag>::new();
-    for bix in mkBlockIx(0).dotdot(mkBlockIx(self.blocks.len())) {
-      self.get_RangeFrags_for_block(
-        bix,
-        &livein_sets_per_block[bix],
-        &liveout_sets_per_block[bix],
-        &mut resMap,
-        &mut resFEnv,
-      );
-    }
-    (resMap, resFEnv)
+#[inline(never)]
+fn get_RangeFrags<F: Function>(
+  f: &F, livein_sets_per_block: &TypedIxVec<BlockIx, Set<Reg>>,
+  liveout_sets_per_block: &TypedIxVec<BlockIx, Set<Reg>>,
+) -> (Map<Reg, Vec<RangeFragIx>>, TypedIxVec<RangeFragIx, RangeFrag>) {
+  debug_assert!(livein_sets_per_block.len() == f.blocks().len() as u32);
+  debug_assert!(liveout_sets_per_block.len() == f.blocks().len() as u32);
+  let mut resMap = Map::<Reg, Vec<RangeFragIx>>::default();
+  let mut resFEnv = TypedIxVec::<RangeFragIx, RangeFrag>::new();
+  for bix in f.blocks() {
+    get_RangeFrags_for_block(
+      f,
+      bix,
+      &livein_sets_per_block[bix],
+      &liveout_sets_per_block[bix],
+      &mut resMap,
+      &mut resFEnv,
+    );
   }
+  (resMap, resFEnv)
 }
 
 //=============================================================================
@@ -850,7 +839,7 @@ fn merge_RangeFrags(
 fn set_VirtualRange_metrics(
   vlrs: &mut TypedIxVec<VirtualRangeIx, VirtualRange>,
   fenv: &TypedIxVec<RangeFragIx, RangeFrag>,
-  blocks: &TypedIxVec<BlockIx, Block>,
+  estFreq: &TypedIxVec<BlockIx, u32>,
 ) {
   for vlr in vlrs.iter_mut() {
     debug_assert!(vlr.size == 0 && vlr.spillCost == Some(0.0));
@@ -873,7 +862,7 @@ fn set_VirtualRange_metrics(
       }
 
       // tot_cost is a float, so no such paranoia there.
-      tot_cost += frag.count as f32 * blocks[frag.bix].estFreq as f32;
+      tot_cost += frag.count as f32 * estFreq[frag.bix] as f32;
     }
 
     debug_assert!(tot_cost >= 0.0);
@@ -890,8 +879,8 @@ fn set_VirtualRange_metrics(
 }
 
 #[inline(never)]
-pub fn run_analysis(
-  func: &mut Func,
+pub fn run_analysis<F: Function>(
+  func: &F,
 ) -> Result<
   (
     TypedIxVec<RealRangeIx, RealRange>,
@@ -900,9 +889,9 @@ pub fn run_analysis(
   ),
   String,
 > {
-  let (def_sets_per_block, use_sets_per_block) = func.calc_def_and_use();
-  debug_assert!(def_sets_per_block.len() == func.blocks.len());
-  debug_assert!(use_sets_per_block.len() == func.blocks.len());
+  let (def_sets_per_block, use_sets_per_block) = calc_def_and_use(func);
+  debug_assert!(def_sets_per_block.len() == func.blocks().len() as u32);
+  debug_assert!(use_sets_per_block.len() == func.blocks().len() as u32);
 
   let mut n = 0;
   println!("");
@@ -911,7 +900,7 @@ pub fn run_analysis(
     n += 1;
   }
 
-  let cfg_info = CFGInfo::create(&func);
+  let cfg_info = CFGInfo::create(func);
 
   n = 0;
   println!("");
@@ -929,7 +918,8 @@ pub fn run_analysis(
   }
 
   // Annotate each Block with its estimated execution frequency
-  for bix in mkBlockIx(0).dotdot(mkBlockIx(func.blocks.len())) {
+  let mut estFreqs = TypedIxVec::new();
+  for bix in func.blocks() {
     let mut estFreq = 1;
     let mut depth = cfg_info.depth_map[bix];
     if depth > 3 {
@@ -938,17 +928,18 @@ pub fn run_analysis(
     for i in 0..depth {
       estFreq *= 10;
     }
-    func.blocks[bix].estFreq = estFreq;
+    assert!(bix == mkBlockIx(estFreqs.len()));
+    estFreqs.push(estFreq);
   }
 
-  let (livein_sets_per_block, liveout_sets_per_block) = func
-    .calc_livein_and_liveout(
-      &def_sets_per_block,
-      &use_sets_per_block,
-      &cfg_info,
-    );
-  debug_assert!(livein_sets_per_block.len() == func.blocks.len());
-  debug_assert!(liveout_sets_per_block.len() == func.blocks.len());
+  let (livein_sets_per_block, liveout_sets_per_block) = calc_livein_and_liveout(
+    func,
+    &def_sets_per_block,
+    &use_sets_per_block,
+    &cfg_info,
+  );
+  debug_assert!(livein_sets_per_block.len() == func.blocks().len() as u32);
+  debug_assert!(liveout_sets_per_block.len() == func.blocks().len() as u32);
 
   n = 0;
   println!("");
@@ -964,12 +955,12 @@ pub fn run_analysis(
     n += 1;
   }
 
-  if !livein_sets_per_block[func.entry.getBlockIx()].is_empty() {
+  if !livein_sets_per_block[func.entry_block()].is_empty() {
     return Err("entry block has live-in values".to_string());
   }
 
   let (fragIxs_per_reg, mut frag_env) =
-    func.get_RangeFrags(&livein_sets_per_block, &liveout_sets_per_block);
+    get_RangeFrags(func, &livein_sets_per_block, &liveout_sets_per_block);
 
   println!("");
   n = 0;
@@ -985,7 +976,7 @@ pub fn run_analysis(
 
   let (rlr_env, mut vlr_env) =
     merge_RangeFrags(&fragIxs_per_reg, &frag_env, &cfg_info);
-  set_VirtualRange_metrics(&mut vlr_env, &frag_env, &func.blocks);
+  set_VirtualRange_metrics(&mut vlr_env, &frag_env, &estFreqs);
 
   println!("");
   n = 0;

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -321,7 +321,6 @@ fn calc_def_and_use<F: Function>(
     let mut uce = Set::empty();
     for iix in f.block_insns(b) {
       let reg_usage = f.get_regs(f.get_insn(iix));
-      println!("insn {:?}: reg_usage {:?}", iix, reg_usage);
       // Add to |uce|, any registers for which the first event
       // in this block is a read.  Dealing with the "first event"
       // constraint is a bit tricky.

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -321,6 +321,7 @@ fn calc_def_and_use<F: Function>(
     let mut uce = Set::empty();
     for iix in f.block_insns(b) {
       let reg_usage = f.get_regs(f.get_insn(iix));
+      println!("insn {:?}: reg_usage {:?}", iix, reg_usage);
       // Add to |uce|, any registers for which the first event
       // in this block is a read.  Dealing with the "first event"
       // constraint is a bit tricky.

--- a/src/backtracking.rs
+++ b/src/backtracking.rs
@@ -1126,6 +1126,6 @@ pub fn alloc_main<F: Function>(
     insns,
     target_map,
     clobbered_registers,
-    num_spill_slots: nextSpillSlot,
+    num_spill_slots: nextSpillSlot.get(),
   })
 }

--- a/src/backtracking.rs
+++ b/src/backtracking.rs
@@ -5,14 +5,14 @@
 
 use crate::analysis::run_analysis;
 use crate::data_structures::{
-  i_reload, i_spill, mkBlockIx, mkInstIx, mkInstPoint, mkRangeFrag,
-  mkRangeFragIx, mkRealReg, mkSpillSlot, mkVirtualRangeIx, rc_from_u32, Block,
-  BlockIx, Func, Inst, InstIx, InstPoint, InstPoint_Def, InstPoint_Reload,
-  InstPoint_Spill, InstPoint_Use, Map, Point, RangeFrag, RangeFragIx,
-  RangeFragKind, RealRange, RealReg, RealRegUniverse, Reg, Set,
-  SortedRangeFragIxs, SpillSlot, TypedIxVec, VirtualRange, VirtualRangeIx,
-  VirtualReg,
+  mkBlockIx, mkInstIx, mkInstPoint, mkRangeFrag, mkRangeFragIx, mkRealReg,
+  mkSpillSlot, mkVirtualRangeIx, BlockIx, InstIx, InstPoint, InstPoint_Def,
+  InstPoint_Reload, InstPoint_Spill, InstPoint_Use, Map, Point, RangeFrag,
+  RangeFragIx, RangeFragKind, RealRange, RealReg, RealRegUniverse, Reg,
+  RegClass, Set, SortedRangeFragIxs, SpillSlot, TypedIxVec, VirtualRange,
+  VirtualRangeIx, VirtualReg,
 };
+use crate::tests::{i_reload, i_spill, Block, Func, Inst};
 use std::fmt;
 
 //=============================================================================
@@ -460,7 +460,7 @@ pub fn alloc_main(
           // Urk.  This is very ungood.  Game over.
           let s = format!(
             "no available registers for class {:?}",
-            rc_from_u32(curr_vlr_rc as u32)
+            RegClass::rc_from_u32(curr_vlr_rc as u32)
           );
           return Err(s);
         }

--- a/src/backtracking.rs
+++ b/src/backtracking.rs
@@ -12,7 +12,7 @@ use crate::data_structures::{
   RegClass, Set, SortedRangeFragIxs, SpillSlot, TypedIxVec, VirtualRange,
   VirtualRangeIx, VirtualReg,
 };
-use crate::tests::{i_reload, i_spill, Block, Func, Inst};
+use crate::interface::{Function, RegAllocResult};
 use std::fmt;
 
 //=============================================================================
@@ -379,15 +379,16 @@ fn show_commit_tab(commit_tab: &Vec::<SortedRangeFragIxs>,
 }
 */
 
-// Allocator top level.  |func| is modified so that, when this function
-// returns, it will contain no VirtualReg uses.  Allocation can fail if there
-// are insufficient registers to even generate spill/reload code, or if the
-// function appears to have any undefined VirtualReg/RealReg uses.
+// Allocator top level.  This function returns a result struct that contains the final sequence of
+// instructions, possibly with fills/spills/moves spliced in and reundant moves elided, and with
+// all virtual registers replaced with real registers. Allocation can fail if there are
+// insufficient registers to even generate spill/reload code, or if the function appears to have
+// any undefined VirtualReg/RealReg uses.
 
 #[inline(never)]
-pub fn alloc_main(
-  func: &mut Func, reg_universe: &RealRegUniverse,
-) -> Result<(), String> {
+pub fn alloc_main<F: Function>(
+  func: &mut F, reg_universe: &RealRegUniverse,
+) -> Result<RegAllocResult<F>, String> {
   // Note that the analysis phase can fail; hence we propagate any error.
   let (rlr_env, mut vlr_env, mut frag_env) = run_analysis(func)?;
 
@@ -430,7 +431,7 @@ pub fn alloc_main(
   );
 
   // This is technically part of the running state, at least for now.
-  let mut spillSlotCtr: u32 = 0;
+  let mut nextSpillSlot: SpillSlot = mkSpillSlot(0);
 
   // Main allocation loop.  Each time round, pull out the longest
   // unallocated VirtualRange, and do one of three things:
@@ -604,25 +605,27 @@ pub fn alloc_main(
     }
     let mut sri_vec = Vec::<SpillAndOrReloadInfo>::new();
     let curr_vlr_vreg = curr_vlr.vreg;
+    let curr_vlr_class = curr_vlr_vreg.get_class();
     let curr_vlr_reg = curr_vlr_vreg.to_reg();
 
     for fix in &curr_vlr.sortedFrags.fragIxs {
       let frag: &RangeFrag = &frag_env[*fix];
       for iix in frag.first.iix.dotdot(frag.last.iix.plus(1)) {
-        let insn: &Inst = &func.insns[iix];
-        let (regs_d, regs_m, regs_u) = insn.get_reg_usage();
+        let reg_usage = func.get_regs(func.get_insn(iix));
         // If this insn doesn't mention the vreg we're spilling for,
         // move on.
-        if !regs_d.contains(curr_vlr_reg)
-          && !regs_m.contains(curr_vlr_reg)
-          && !regs_u.contains(curr_vlr_reg)
+        if !reg_usage.defined.contains(curr_vlr_reg)
+          && !reg_usage.modified.contains(curr_vlr_reg)
+          && !reg_usage.used.contains(curr_vlr_reg)
         {
           continue;
         }
         // USES: Do we need to create a reload-to-use bridge
         // (VirtualRange) ?
-        if regs_u.contains(curr_vlr_reg) && frag.contains(&InstPoint_Use(iix)) {
-          debug_assert!(!regs_m.contains(curr_vlr_reg));
+        if reg_usage.used.contains(curr_vlr_reg)
+          && frag.contains(&InstPoint_Use(iix))
+        {
+          debug_assert!(!reg_usage.modified.contains(curr_vlr_reg));
           // Stash enough info that we can create a new VirtualRange
           // and a new edit list entry for the reload.
           let sri =
@@ -635,19 +638,21 @@ pub fn alloc_main(
         // two (one for the reload, one for the spill) they could
         // later end up being assigned to different RealRegs, which is
         // obviously nonsensical.
-        if regs_m.contains(curr_vlr_reg)
+        if reg_usage.modified.contains(curr_vlr_reg)
           && frag.contains(&InstPoint_Use(iix))
           && frag.contains(&InstPoint_Def(iix))
         {
-          debug_assert!(!regs_u.contains(curr_vlr_reg));
-          debug_assert!(!regs_d.contains(curr_vlr_reg));
+          debug_assert!(!reg_usage.used.contains(curr_vlr_reg));
+          debug_assert!(!reg_usage.defined.contains(curr_vlr_reg));
           let sri =
             SpillAndOrReloadInfo { bix: frag.bix, iix, kind: BridgeKind::RtoS };
           sri_vec.push(sri);
         }
         // DEFS: Do we need to create a def-to-spill bridge?
-        if regs_d.contains(curr_vlr_reg) && frag.contains(&InstPoint_Def(iix)) {
-          debug_assert!(!regs_m.contains(curr_vlr_reg));
+        if reg_usage.defined.contains(curr_vlr_reg)
+          && frag.contains(&InstPoint_Def(iix))
+        {
+          debug_assert!(!reg_usage.modified.contains(curr_vlr_reg));
           let sri =
             SpillAndOrReloadInfo { bix: frag.bix, iix, kind: BridgeKind::DtoS };
           sri_vec.push(sri);
@@ -658,6 +663,8 @@ pub fn alloc_main(
     // Now that we no longer need to access |frag_env| or |vlr_env| for
     // the remainder of this iteration of the main allocation loop, we can
     // actually generate the required spill/reload artefacts.
+    let num_slots = func.get_spillslot_size(curr_vlr_class);
+    nextSpillSlot = nextSpillSlot.round_up(num_slots);
     for sri in sri_vec {
       // For a spill for a MOD use, the new value will be referenced
       // three times.  For DEF and USE uses, it'll only be ref'd twice.
@@ -698,16 +705,13 @@ pub fn alloc_main(
       vlr_env.push(new_vlr);
       prioQ.add_VirtualRange(new_vlrix);
 
-      let new_eli = EditListItem {
-        slot: mkSpillSlot(spillSlotCtr),
-        vlrix: new_vlrix,
-        kind: sri.kind,
-      };
+      let new_eli =
+        EditListItem { slot: nextSpillSlot, vlrix: new_vlrix, kind: sri.kind };
       println!("--     new ELI        {:?}", &new_eli);
       editList.push(new_eli);
     }
 
-    spillSlotCtr += 1;
+    nextSpillSlot = nextSpillSlot.inc(num_slots);
   }
 
   println!("");
@@ -818,7 +822,7 @@ pub fn alloc_main(
     false
   }
 
-  for insnIx in mkInstIx(0).dotdot(mkInstIx(func.insns.len())) {
+  for insnIx in func.insn_indices() {
     //println!("");
     //println!("QQQQ insn {}: {}",
     //         insnIx, func.insns[insnIx].show());
@@ -901,6 +905,9 @@ pub fn alloc_main(
     //   remove frags ending at I.s
     // apply mapU/mapD to I
 
+    //println!("QQQQ mapping insn {:?}", insnIx);
+    //println!("QQQQ current map {}", showMap(&map));
+
     // Update map for I.r:
     //   add frags starting at I.r
     //   no frags should end at I.r (it's a reload insn)
@@ -909,6 +916,10 @@ pub fn alloc_main(
       if frag.first.pt.isReload() {
         //////// STARTS at I.r
         map.insert(fragMapsByStart[j].1, fragMapsByStart[j].2);
+        //println!(
+        //  "QQQQ inserted frag from reload: {:?} -> {:?}",
+        //  fragMapsByStart[j].1, fragMapsByStart[j].2
+        //);
       }
     }
 
@@ -921,6 +932,10 @@ pub fn alloc_main(
       if frag.first.pt.isUse() {
         //////// STARTS at I.u
         map.insert(fragMapsByStart[j].1, fragMapsByStart[j].2);
+        //println!(
+        //  "QQQQ inserted frag from use: {:?} -> {:?}",
+        //  fragMapsByStart[j].1, fragMapsByStart[j].2
+        //);
       }
     }
     let mapU = map.clone();
@@ -929,6 +944,7 @@ pub fn alloc_main(
       if frag.last.pt.isUse() {
         //////// ENDS at I.U
         map.remove(&fragMapsByEnd[j].1);
+        //println!("QQQQ removed frag after use: {:?}", fragMapsByStart[j].1);
       }
     }
 
@@ -941,6 +957,10 @@ pub fn alloc_main(
       if frag.first.pt.isDef() {
         //////// STARTS at I.d
         map.insert(fragMapsByStart[j].1, fragMapsByStart[j].2);
+        //println!(
+        //  "QQQQ inserted frag from def: {:?} -> {:?}",
+        //  fragMapsByStart[j].1, fragMapsByStart[j].2
+        //);
       }
     }
     let mapD = map.clone();
@@ -949,6 +969,7 @@ pub fn alloc_main(
       if frag.last.pt.isDef() {
         //////// ENDS at I.d
         map.remove(&fragMapsByEnd[j].1);
+        //println!("QQQQ ended frag from def: {:?}", fragMapsByEnd[j].1);
       }
     }
 
@@ -960,6 +981,7 @@ pub fn alloc_main(
       if frag.last.pt.isSpill() {
         //////// ENDS at I.s
         map.remove(&fragMapsByEnd[j].1);
+        //println!("QQQQ ended frag from spill: {:?}", fragMapsByEnd[j].1);
       }
     }
 
@@ -968,15 +990,18 @@ pub fn alloc_main(
 
     // Finally, we have mapU/mapD set correctly for this instruction.
     // Apply it.
-    func.insns[insnIx].mapRegs_D_U(&mapD, &mapU);
+    let mut insn = func.get_insn_mut(insnIx);
+    F::map_regs(&mut insn, &mapU, &mapD);
 
     // Update cursorStarts and cursorEnds for the next iteration
     cursorStarts += numStarts;
     cursorEnds += numEnds;
 
-    if func.blocks.iter().any(|b| b.start.plus(b.len).minus(1) == insnIx) {
-      //println!("Block end");
-      debug_assert!(map.is_empty());
+    for b in func.blocks() {
+      if func.block_insns(b).last() == insnIx {
+        //println!("Block end");
+        debug_assert!(map.is_empty());
+      }
     }
   }
 
@@ -987,8 +1012,9 @@ pub fn alloc_main(
   // are missing.  To generate them, go through the "edit list", which
   // contains info on both how to generate the instructions, and where to
   // insert them.
-  let mut spillsAndReloads = Vec::<(InstPoint, Inst)>::new();
+  let mut spillsAndReloads = Vec::<(InstPoint, F::Inst)>::new();
   for eli in &editList {
+    println!("editlist entry: {:?}", eli);
     let vlr = &vlr_env[eli.vlrix];
     let vlr_sfrags = &vlr.sortedFrags;
     debug_assert!(vlr.sortedFrags.fragIxs.len() == 1);
@@ -999,7 +1025,7 @@ pub fn alloc_main(
         debug_assert!(vlr_frag.first.pt.isReload());
         debug_assert!(vlr_frag.last.pt.isUse());
         debug_assert!(vlr_frag.first.iix == vlr_frag.last.iix);
-        let insnR = i_reload(rreg, eli.slot);
+        let insnR = func.gen_reload(eli.slot, rreg);
         let whereToR = vlr_frag.first;
         spillsAndReloads.push((whereToR, insnR));
       }
@@ -1007,9 +1033,9 @@ pub fn alloc_main(
         debug_assert!(vlr_frag.first.pt.isReload());
         debug_assert!(vlr_frag.last.pt.isSpill());
         debug_assert!(vlr_frag.first.iix == vlr_frag.last.iix);
-        let insnR = i_reload(rreg, eli.slot);
+        let insnR = func.gen_reload(eli.slot, rreg);
         let whereToR = vlr_frag.first;
-        let insnS = i_spill(eli.slot, rreg);
+        let insnS = func.gen_spill(rreg, eli.slot);
         let whereToS = vlr_frag.last;
         spillsAndReloads.push((whereToR, insnR));
         spillsAndReloads.push((whereToS, insnS));
@@ -1018,7 +1044,7 @@ pub fn alloc_main(
         debug_assert!(vlr_frag.first.pt.isDef());
         debug_assert!(vlr_frag.last.pt.isSpill());
         debug_assert!(vlr_frag.first.iix == vlr_frag.last.iix);
-        let insnS = i_spill(eli.slot, rreg);
+        let insnS = func.gen_spill(rreg, eli.slot);
         let whereToS = vlr_frag.last;
         spillsAndReloads.push((whereToS, insnS));
       }
@@ -1042,63 +1068,64 @@ pub fn alloc_main(
   let mut curSnR = 0; // cursor in |spillsAndReloads|
   let mut curB = mkBlockIx(0); // cursor in Func::blocks
 
-  let mut newInsts = TypedIxVec::<InstIx, Inst>::new();
-  let mut newBlocks = TypedIxVec::<BlockIx, Block>::new();
+  let mut insns: Vec<F::Inst> = vec![];
+  let mut target_map: Map<BlockIx, InstIx> = Map::default();
+  let mut clobbered_registers: Set<RealReg> = Set::empty();
 
-  for iix in mkInstIx(0).dotdot(mkInstIx(func.insns.len())) {
+  for iix in func.insn_indices() {
     // Is |iix| the first instruction in a block?  Meaning, are we
     // starting a new block?
-    debug_assert!(curB.get() < func.blocks.len());
-    if func.blocks[curB].start == iix {
-      let oldBlock = &func.blocks[curB];
-      let newBlock = Block {
-        name: oldBlock.name.clone(),
-        start: mkInstIx(newInsts.len() as u32),
-        len: 0,
-        estFreq: oldBlock.estFreq,
-      };
-      newBlocks.push(newBlock);
+    debug_assert!(curB.get() < func.blocks().len() as u32);
+    if func.block_insns(curB).start() == iix {
+      target_map.insert(curB, mkInstIx(insns.len() as u32));
     }
 
     // Copy reloads for this insn
     while curSnR < spillsAndReloads.len()
       && spillsAndReloads[curSnR].0 == InstPoint_Reload(iix)
     {
-      newInsts.push(spillsAndReloads[curSnR].1.clone());
+      insns.push(spillsAndReloads[curSnR].1.clone());
       curSnR += 1;
     }
     // And the insn itself
-    newInsts.push(func.insns[iix].clone());
+    insns.push(func.get_insn(iix).clone());
     // Copy spills for this insn
     while curSnR < spillsAndReloads.len()
       && spillsAndReloads[curSnR].0 == InstPoint_Spill(iix)
     {
-      newInsts.push(spillsAndReloads[curSnR].1.clone());
+      insns.push(spillsAndReloads[curSnR].1.clone());
       curSnR += 1;
     }
 
     // Is |iix| the last instruction in a block?
-    if iix.plus(1) == func.blocks[curB].start.plus(func.blocks[curB].len) {
-      debug_assert!(curB.get() < func.blocks.len());
-      debug_assert!(newBlocks.len() > 0);
-      debug_assert!(curB.get() == newBlocks.len() - 1);
-      newBlocks[curB].len = newInsts.len() as u32 - newBlocks[curB].start.get();
+    if iix == func.block_insns(curB).last() {
+      debug_assert!(curB.get() < func.blocks().len() as u32);
       curB = curB.plus(1);
     }
   }
 
   debug_assert!(curSnR == spillsAndReloads.len());
-  debug_assert!(curB.get() == func.blocks.len());
-  debug_assert!(curB.get() == newBlocks.len());
+  debug_assert!(curB.get() == func.blocks().len() as u32);
 
-  func.insns = newInsts;
-  func.blocks = newBlocks;
+  // Compute clobbered registers with one final, quick pass. Assert that all registers are real,
+  // not virtual, as an extra sanity check.
+  for insn in insns.iter() {
+    let reg_usage = func.get_regs(insn);
+    for reg in reg_usage.used.iter() {
+      assert!(reg.is_real());
+    }
+    for reg in reg_usage.modified.iter().chain(reg_usage.defined.iter()) {
+      assert!(reg.is_real());
+      clobbered_registers.insert(reg.to_real_reg());
+    }
+  }
 
   // And we're done!
-  //
-  // Curiously, there's no need to fix up Labels after having merged the
-  // spill and original instructions.  That's because Labels refer to
-  // Blocks, not to individual Insts.  Obviously in a real system things are
-  // different :-/
-  Ok(())
+
+  Ok(RegAllocResult {
+    insns,
+    target_map,
+    clobbered_registers,
+    num_spill_slots: nextSpillSlot,
+  })
 }

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -421,10 +421,9 @@ impl Reg {
       (self.do_not_access_this_directly & ((1 << 8) - 1)) as usize
     }
   }
-  // TODO rename; what does "enc" mean?
-  pub fn get_enc(self) -> u8 {
+  pub fn get_hw_encoding(self) -> u8 {
     if self.is_virtual() {
-      panic!("Reg::get_enc on virtual register")
+      panic!("Virtual register does not have a hardware encoding")
     } else {
       ((self.do_not_access_this_directly >> 8) & ((1 << 8) - 1)) as u8
     }
@@ -486,6 +485,9 @@ impl RealReg {
   }
   pub fn get_index(self) -> usize {
     self.reg.get_index()
+  }
+  pub fn get_hw_encoding(self) -> usize {
+    self.reg.get_hw_encoding() as usize
   }
   pub fn to_reg(self) -> Reg {
     self.reg

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -161,6 +161,10 @@ impl<'a, T> Iterator for SetIter<'a, T> {
 //   for ent in startEnt .. endPlus1Ent {
 //   }
 
+trait Zero {
+  fn zero() -> Self;
+}
+
 trait PlusOne {
   fn plus_one(&self) -> Self;
 }
@@ -240,7 +244,7 @@ pub struct TypedIxVec<TyIx, Ty> {
 impl<TyIx, Ty> TypedIxVec<TyIx, Ty>
 where
   Ty: Clone,
-  TyIx: From<u32> + Copy + Eq + Ord + PlusOne + PlusN,
+  TyIx: Copy + Eq + Ord + Zero + PlusOne + PlusN,
 {
   pub fn new() -> Self {
     Self { vek: Vec::new(), ty_ix: PhantomData::<TyIx> }
@@ -276,7 +280,7 @@ where
     &mut self.vek[..]
   }
   pub fn range(&self) -> MyRange<TyIx> {
-    MyRange::new(TyIx::from(0), self.len() as usize)
+    MyRange::new(TyIx::zero(), self.len() as usize)
   }
 }
 
@@ -361,9 +365,9 @@ macro_rules! generate_boilerplate {
         self.get()
       }
     }
-    impl From<u32> for $TypeIx {
-      fn from(val: u32) -> Self {
-        $TypeIx::$TypeIx(val)
+    impl Zero for $TypeIx {
+      fn zero() -> Self {
+        $mkTypeIx(0)
       }
     }
   };
@@ -435,8 +439,10 @@ impl RegClass {
 
   pub fn short_name(self) -> &'static str {
     match self {
-      RegClass::I32 | RegClass::I64 => "I",
-      RegClass::F32 | RegClass::F64 => "F",
+      RegClass::I32 => "I",
+      RegClass::I64 => "J",
+      RegClass::F32 => "F",
+      RegClass::F64 => "D",
       RegClass::V128 => "V",
     }
   }

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -176,6 +176,13 @@ impl<T: Copy + PartialOrd + PlusOne> IntoIterator for MyRange<T> {
   }
 }
 
+impl<T> MyRange<T> {
+  /// Create a new range object.
+  pub fn new(from: T, to: T) -> MyRange<T> {
+    MyRange { first: from, lastPlus1: to }
+  }
+}
+
 pub struct MyIterator<T> {
   range: MyRange<T>,
   next: T,
@@ -204,6 +211,7 @@ pub struct TypedIxVec<TyIx, Ty> {
 impl<TyIx, Ty> TypedIxVec<TyIx, Ty>
 where
   Ty: Clone,
+  TyIx: From<u32>,
 {
   pub fn new() -> Self {
     Self { vek: Vec::new(), ty_ix: PhantomData::<TyIx> }
@@ -211,7 +219,7 @@ where
   pub fn fromVec(vek: Vec<Ty>) -> Self {
     Self { vek, ty_ix: PhantomData::<TyIx> }
   }
-  fn append(&mut self, other: &mut TypedIxVec<TyIx, Ty>) {
+  pub fn append(&mut self, other: &mut TypedIxVec<TyIx, Ty>) {
     // FIXME what if this overflows?
     self.vek.append(&mut other.vek);
   }
@@ -231,6 +239,12 @@ where
   }
   pub fn resize(&mut self, new_len: u32, value: Ty) {
     self.vek.resize(new_len as usize, value);
+  }
+  pub fn elems(&self) -> &[Ty] {
+    &self.vek[..]
+  }
+  pub fn range(&self) -> MyRange<TyIx> {
+    MyRange::new(TyIx::from(0), TyIx::from(self.len()))
   }
 }
 
@@ -309,6 +323,11 @@ macro_rules! generate_boilerplate {
         self.get()
       }
     }
+    impl From<u32> for $TypeIx {
+      fn from(val: u32) -> Self {
+        $TypeIx::$TypeIx(val)
+      }
+    }
   };
 }
 
@@ -331,42 +350,49 @@ impl<TyIx, Ty: fmt::Debug> fmt::Debug for TypedIxVec<TyIx, Ty> {
 }
 
 //=============================================================================
-// Definitions of register classes, registers and stack slots, and printing
-// thereof.
+// Definitions of register classes, registers and stack slots, and printing thereof. Note that this
+// register class definition is meant to be architecture-independent: it simply captures common
+// integer/float/vector types that machines are likely to use. TODO: investigate whether we need a
+// more flexible register-class definition mechanism.
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum RegClass {
   I32,
   F32,
+  I64,
+  F64,
+  V128,
 }
 
-impl fmt::Debug for RegClass {
-  fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-    match self {
-      RegClass::I32 => write!(fmt, "I"),
-      RegClass::F32 => write!(fmt, "F"),
-    }
-  }
-}
-
-const NUM_REG_CLASSES: usize = 2;
+/// The number of register classes that exist.
+/// N.B.: must be <= 7 (fit into 3 bits) for 32-bit VReg/RReg packed format!
+pub const NUM_REG_CLASSES: usize = 5;
 
 impl RegClass {
-  fn rc_to_u32(self) -> u32 {
+  /// Convert a register class to a u32 index.
+  pub fn rc_to_u32(self) -> u32 {
     match self {
       RegClass::I32 => 0,
       RegClass::F32 => 1,
+      RegClass::I64 => 2,
+      RegClass::F64 => 3,
+      RegClass::V128 => 4,
     }
   }
+  /// Convert a register class to a usize index.
   pub fn rc_to_usize(self) -> usize {
     self.rc_to_u32() as usize
   }
-}
-pub fn rc_from_u32(rc: u32) -> RegClass {
-  match rc {
-    0 => RegClass::I32,
-    1 => RegClass::F32,
-    _ => panic!("rc_from_u32"),
+  /// Construct a register class from a u32.
+  pub fn rc_from_u32(rc: u32) -> RegClass {
+    match rc {
+      0 => RegClass::I32,
+      1 => RegClass::F32,
+      2 => RegClass::I64,
+      3 => RegClass::F64,
+      4 => RegClass::V128,
+      _ => panic!("rc_from_u32"),
+    }
   }
 }
 
@@ -410,7 +436,7 @@ impl Reg {
     (self.do_not_access_this_directly & 0x8000_0000) != 0
   }
   pub fn get_class(self) -> RegClass {
-    rc_from_u32((self.do_not_access_this_directly >> 28) & 0x7)
+    RegClass::rc_from_u32((self.do_not_access_this_directly >> 28) & 0x7)
   }
   pub fn get_index(self) -> usize {
     // Return type is usize because typically we will want to use the
@@ -532,7 +558,7 @@ impl fmt::Debug for VirtualReg {
 impl Reg {
   // Apply a vreg-rreg mapping to a Reg.  This used for registers used in
   // either a read- or a write-role.
-  fn apply_D_or_U(&mut self, map: &Map<VirtualReg, RealReg>) {
+  pub fn apply_D_or_U(&mut self, map: &Map<VirtualReg, RealReg>) {
     if let Some(vreg) = self.as_virtual_reg() {
       if let Some(rreg) = map.get(&vreg) {
         debug_assert!(rreg.get_class() == vreg.get_class());
@@ -545,7 +571,7 @@ impl Reg {
   // Apply a pair of vreg-rreg mappings to a Reg.  The mappings *must*
   // agree!  This seems a bit strange at first.  It is used for registers
   // used in a modify-role.
-  fn apply_M(
+  pub fn apply_M(
     &mut self, mapD: &Map<VirtualReg, RealReg>, mapU: &Map<VirtualReg, RealReg>,
   ) {
     if let Some(vreg) = self.as_virtual_reg() {
@@ -642,9 +668,9 @@ pub struct RealRegUniverse {
 }
 
 impl RealRegUniverse {
-  // Check that the given universe satisfies various invariants, and panic
-  // if not.  All the invariants are important.
-  fn check_is_sane(&self) {
+  /// Check that the given universe satisfies various invariants, and panic
+  /// if not.  All the invariants are important.
+  pub fn check_is_sane(&self) {
     let regs_len = self.regs.len();
     let regs_allocable = self.allocable;
     // The universe must contain at most 256 registers.  That's because
@@ -703,7 +729,7 @@ impl RealRegUniverse {
             if ok {
               for i in first..last + 1 {
                 let (reg, _name) = &self.regs[i];
-                if ok && rc_from_u32(rc as u32) != reg.get_class() {
+                if ok && RegClass::rc_from_u32(rc as u32) != reg.get_class() {
                   ok = false;
                 }
                 regs_visited += 1;
@@ -720,888 +746,6 @@ impl RealRegUniverse {
     if !ok {
       panic!("RealRegUniverse::check_is_sane: invalid RealRegUniverse");
     }
-  }
-}
-
-// Create a universe for testing, with nI32 |I32| class regs and nF32 |F32|
-// class regs.
-
-pub fn make_universe(nI32: usize, nF32: usize) -> RealRegUniverse {
-  let total_regs = nI32 + nF32;
-  if total_regs >= 256 {
-    panic!("make_universe: too many regs, cannot represent");
-  }
-
-  let mut regs = Vec::<(RealReg, String)>::new();
-  let mut allocable_by_class = [None; NUM_REG_CLASSES];
-  let mut index = 0u8;
-
-  if nI32 > 0 {
-    let first = index as usize;
-    for i in 0..nI32 {
-      let name = format!("R{}", i).to_string();
-      let reg = mkRealReg(RegClass::I32, /*enc=*/ 0, index).to_real_reg();
-      regs.push((reg, name));
-      index += 1;
-    }
-    let last = index as usize - 1;
-    allocable_by_class[RegClass::I32.rc_to_usize()] = Some((first, last));
-  }
-
-  if nF32 > 0 {
-    let first = index as usize;
-    for i in 0..nF32 {
-      let name = format!("F{}", i).to_string();
-      let reg = mkRealReg(RegClass::F32, /*enc=*/ 0, index).to_real_reg();
-      regs.push((reg, name));
-      index += 1;
-    }
-    let last = index as usize - 1;
-    allocable_by_class[RegClass::F32.rc_to_usize()] = Some((first, last));
-  }
-
-  debug_assert!(index as usize == total_regs);
-
-  let allocable = regs.len();
-  let univ = RealRegUniverse {
-    regs,
-    // for this example, all regs are allocable
-    allocable,
-    allocable_by_class,
-  };
-  univ.check_is_sane();
-
-  univ
-}
-
-//=============================================================================
-// Definition of instructions, and printing thereof.  Destinations are on the
-// left.
-
-#[derive(Clone)]
-pub enum Label {
-  Unresolved { name: String },
-  Resolved { name: String, bix: BlockIx },
-}
-impl fmt::Debug for Label {
-  fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-    match self {
-      Label::Unresolved { name } => write!(fmt, "??:{}", &name),
-      Label::Resolved { name, bix } => write!(fmt, "{:?}:{:?}", bix, name),
-    }
-  }
-}
-impl Label {
-  pub fn getBlockIx(&self) -> BlockIx {
-    match self {
-      Label::Resolved { name: _, bix } => *bix,
-      Label::Unresolved { .. } => {
-        panic!("Label::getBlockIx: unresolved label!")
-      }
-    }
-  }
-
-  pub fn remapControlFlow(&mut self, from: &String, to: &String) {
-    match self {
-      Label::Resolved { .. } => {
-        panic!("Label::remapControlFlow on resolved label");
-      }
-      Label::Unresolved { name } => {
-        if name == from {
-          *name = to.clone();
-        }
-      }
-    }
-  }
-}
-pub fn mkTextLabel(n: usize) -> String {
-  "L".to_string() + &n.to_string()
-}
-fn mkUnresolved(name: String) -> Label {
-  Label::Unresolved { name }
-}
-
-#[derive(Copy, Clone)]
-pub enum RI {
-  Reg { reg: Reg },
-  Imm { imm: u32 },
-}
-pub fn RI_R(reg: Reg) -> RI {
-  debug_assert!(reg.get_class() == RegClass::I32);
-  RI::Reg { reg }
-}
-pub fn RI_I(imm: u32) -> RI {
-  RI::Imm { imm }
-}
-impl fmt::Debug for RI {
-  fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-    match self {
-      RI::Reg { reg } => reg.fmt(fmt),
-      RI::Imm { imm } => write!(fmt, "{}", imm),
-    }
-  }
-}
-impl RI {
-  fn addRegReadsTo(&self, uce: &mut Set<Reg>) {
-    match self {
-      RI::Reg { reg } => uce.insert(*reg),
-      RI::Imm { .. } => {}
-    }
-  }
-  fn apply_D_or_U(&mut self, map: &Map<VirtualReg, RealReg>) {
-    match self {
-      RI::Reg { ref mut reg } => {
-        reg.apply_D_or_U(map);
-      }
-      RI::Imm { .. } => {}
-    }
-  }
-}
-
-#[derive(Copy, Clone)]
-pub enum AM {
-  RI { base: Reg, offset: u32 },
-  RR { base: Reg, offset: Reg },
-}
-pub fn AM_R(base: Reg) -> AM {
-  debug_assert!(base.get_class() == RegClass::I32);
-  AM::RI { base, offset: 0 }
-}
-pub fn AM_RI(base: Reg, offset: u32) -> AM {
-  debug_assert!(base.get_class() == RegClass::I32);
-  AM::RI { base, offset }
-}
-pub fn AM_RR(base: Reg, offset: Reg) -> AM {
-  debug_assert!(base.get_class() == RegClass::I32);
-  debug_assert!(offset.get_class() == RegClass::I32);
-  AM::RR { base, offset }
-}
-impl fmt::Debug for AM {
-  fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-    match self {
-      AM::RI { base, offset } => write!(fmt, "[{:?} {:?}]", base, offset),
-      AM::RR { base, offset } => write!(fmt, "[{:?} {:?}]", base, offset),
-    }
-  }
-}
-impl AM {
-  fn addRegReadsTo(&self, uce: &mut Set<Reg>) {
-    match self {
-      AM::RI { base, .. } => uce.insert(*base),
-      AM::RR { base, offset } => {
-        uce.insert(*base);
-        uce.insert(*offset);
-      }
-    }
-  }
-  fn apply_D_or_U(&mut self, map: &Map<VirtualReg, RealReg>) {
-    match self {
-      AM::RI { ref mut base, .. } => {
-        base.apply_D_or_U(map);
-      }
-      AM::RR { ref mut base, ref mut offset } => {
-        base.apply_D_or_U(map);
-        offset.apply_D_or_U(map);
-      }
-    }
-  }
-}
-
-#[derive(Copy, Clone)]
-pub enum BinOp {
-  Add,
-  Sub,
-  Mul,
-  Mod,
-  Shr,
-  And,
-  CmpEQ,
-  CmpLT,
-  CmpLE,
-  CmpGE,
-  CmpGT,
-}
-impl fmt::Debug for BinOp {
-  fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-    write!(
-      fmt,
-      "{}",
-      match self {
-        BinOp::Add => "add",
-        BinOp::Sub => "sub",
-        BinOp::Mul => "mul",
-        BinOp::Mod => "mod",
-        BinOp::Shr => "shr",
-        BinOp::And => "and",
-        BinOp::CmpEQ => "cmpeq",
-        BinOp::CmpLT => "cmplt",
-        BinOp::CmpLE => "cmple",
-        BinOp::CmpGE => "cmpge",
-        BinOp::CmpGT => "cmpgt",
-      }
-    )
-  }
-}
-impl fmt::Display for BinOp {
-  fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-    (self as &dyn fmt::Debug).fmt(fmt)
-  }
-}
-impl BinOp {
-  pub fn calc(self, argL: u32, argR: u32) -> u32 {
-    match self {
-      BinOp::Add => u32::wrapping_add(argL, argR),
-      BinOp::Sub => u32::wrapping_sub(argL, argR),
-      BinOp::Mul => u32::wrapping_mul(argL, argR),
-      BinOp::Mod => argL % argR,
-      BinOp::Shr => argL >> (argR & 31),
-      BinOp::And => argL & argR,
-      BinOp::CmpEQ => {
-        if argL == argR {
-          1
-        } else {
-          0
-        }
-      }
-      BinOp::CmpLT => {
-        if argL < argR {
-          1
-        } else {
-          0
-        }
-      }
-      BinOp::CmpLE => {
-        if argL <= argR {
-          1
-        } else {
-          0
-        }
-      }
-      BinOp::CmpGE => {
-        if argL >= argR {
-          1
-        } else {
-          0
-        }
-      }
-      BinOp::CmpGT => {
-        if argL > argR {
-          1
-        } else {
-          0
-        }
-      }
-    }
-  }
-}
-
-#[derive(Copy, Clone)]
-enum BinOpF {
-  FAdd,
-  FSub,
-  FMul,
-  FDiv,
-}
-impl fmt::Debug for BinOpF {
-  fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-    write!(
-      fmt,
-      "{}",
-      match self {
-        BinOpF::FAdd => "fadd".to_string(),
-        BinOpF::FSub => "fsub".to_string(),
-        BinOpF::FMul => "fmul".to_string(),
-        BinOpF::FDiv => "fdiv".to_string(),
-      }
-    )
-  }
-}
-impl fmt::Display for BinOpF {
-  fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-    (self as &dyn fmt::Debug).fmt(fmt)
-  }
-}
-impl BinOpF {
-  fn calc(self, argL: f32, argR: f32) -> f32 {
-    match self {
-      BinOpF::FAdd => argL + argR,
-      BinOpF::FSub => argL - argR,
-      BinOpF::FMul => argL * argR,
-      BinOpF::FDiv => argL / argR,
-    }
-  }
-}
-
-#[derive(Clone)]
-pub enum Inst {
-  Imm { dst: Reg, imm: u32 },
-  ImmF { dst: Reg, imm: f32 },
-  Copy { dst: Reg, src: Reg },
-  BinOp { op: BinOp, dst: Reg, srcL: Reg, srcR: RI },
-  BinOpM { op: BinOp, dst: Reg, srcR: RI }, // "mod" semantics for |dst|
-  BinOpF { op: BinOpF, dst: Reg, srcL: Reg, srcR: Reg },
-  Load { dst: Reg, addr: AM },
-  LoadF { dst: Reg, addr: AM },
-  Store { addr: AM, src: Reg },
-  StoreF { addr: AM, src: Reg },
-  Spill { dst: SpillSlot, src: RealReg },
-  SpillF { dst: SpillSlot, src: RealReg },
-  Reload { dst: RealReg, src: SpillSlot },
-  ReloadF { dst: RealReg, src: SpillSlot },
-  Goto { target: Label },
-  GotoCTF { cond: Reg, targetT: Label, targetF: Label },
-  PrintS { str: String },
-  PrintI { reg: Reg },
-  PrintF { reg: Reg },
-  Finish {},
-}
-
-pub fn i_imm(dst: Reg, imm: u32) -> Inst {
-  debug_assert!(dst.get_class() == RegClass::I32);
-  Inst::Imm { dst, imm }
-}
-pub fn i_copy(dst: Reg, src: Reg) -> Inst {
-  debug_assert!(dst.get_class() == RegClass::I32);
-  debug_assert!(src.get_class() == RegClass::I32);
-  Inst::Copy { dst, src }
-}
-// For BinOp variants see below
-
-pub fn i_load(dst: Reg, addr: AM) -> Inst {
-  debug_assert!(dst.get_class() == RegClass::I32);
-  Inst::Load { dst, addr }
-}
-pub fn i_store(addr: AM, src: Reg) -> Inst {
-  debug_assert!(src.get_class() == RegClass::I32);
-  Inst::Store { addr, src }
-}
-pub fn i_spill(dst: SpillSlot, src: RealReg) -> Inst {
-  debug_assert!(src.get_class() == RegClass::I32);
-  Inst::Spill { dst, src }
-}
-pub fn i_reload(dst: RealReg, src: SpillSlot) -> Inst {
-  debug_assert!(dst.get_class() == RegClass::I32);
-  Inst::Reload { dst, src }
-}
-pub fn i_goto<'a>(target: &'a str) -> Inst {
-  Inst::Goto { target: mkUnresolved(target.to_string()) }
-}
-pub fn i_goto_ctf<'a>(cond: Reg, targetT: &'a str, targetF: &'a str) -> Inst {
-  debug_assert!(cond.get_class() == RegClass::I32);
-  Inst::GotoCTF {
-    cond,
-    targetT: mkUnresolved(targetT.to_string()),
-    targetF: mkUnresolved(targetF.to_string()),
-  }
-}
-pub fn i_print_s<'a>(str: &'a str) -> Inst {
-  Inst::PrintS { str: str.to_string() }
-}
-pub fn i_print_i(reg: Reg) -> Inst {
-  debug_assert!(reg.get_class() == RegClass::I32);
-  Inst::PrintI { reg }
-}
-pub fn i_finish() -> Inst {
-  Inst::Finish {}
-}
-
-pub fn i_add(dst: Reg, srcL: Reg, srcR: RI) -> Inst {
-  debug_assert!(dst.get_class() == RegClass::I32);
-  debug_assert!(srcL.get_class() == RegClass::I32);
-  Inst::BinOp { op: BinOp::Add, dst, srcL, srcR }
-}
-pub fn i_sub(dst: Reg, srcL: Reg, srcR: RI) -> Inst {
-  debug_assert!(dst.get_class() == RegClass::I32);
-  debug_assert!(srcL.get_class() == RegClass::I32);
-  Inst::BinOp { op: BinOp::Sub, dst, srcL, srcR }
-}
-pub fn i_mul(dst: Reg, srcL: Reg, srcR: RI) -> Inst {
-  debug_assert!(dst.get_class() == RegClass::I32);
-  debug_assert!(srcL.get_class() == RegClass::I32);
-  Inst::BinOp { op: BinOp::Mul, dst, srcL, srcR }
-}
-pub fn i_mod(dst: Reg, srcL: Reg, srcR: RI) -> Inst {
-  debug_assert!(dst.get_class() == RegClass::I32);
-  debug_assert!(srcL.get_class() == RegClass::I32);
-  Inst::BinOp { op: BinOp::Mod, dst, srcL, srcR }
-}
-pub fn i_shr(dst: Reg, srcL: Reg, srcR: RI) -> Inst {
-  debug_assert!(dst.get_class() == RegClass::I32);
-  debug_assert!(srcL.get_class() == RegClass::I32);
-  Inst::BinOp { op: BinOp::Shr, dst, srcL, srcR }
-}
-pub fn i_and(dst: Reg, srcL: Reg, srcR: RI) -> Inst {
-  debug_assert!(dst.get_class() == RegClass::I32);
-  debug_assert!(srcL.get_class() == RegClass::I32);
-  Inst::BinOp { op: BinOp::And, dst, srcL, srcR }
-}
-pub fn i_cmp_eq(dst: Reg, srcL: Reg, srcR: RI) -> Inst {
-  debug_assert!(dst.get_class() == RegClass::I32);
-  debug_assert!(srcL.get_class() == RegClass::I32);
-  Inst::BinOp { op: BinOp::CmpEQ, dst, srcL, srcR }
-}
-pub fn i_cmp_lt(dst: Reg, srcL: Reg, srcR: RI) -> Inst {
-  debug_assert!(dst.get_class() == RegClass::I32);
-  debug_assert!(srcL.get_class() == RegClass::I32);
-  Inst::BinOp { op: BinOp::CmpLT, dst, srcL, srcR }
-}
-pub fn i_cmp_le(dst: Reg, srcL: Reg, srcR: RI) -> Inst {
-  debug_assert!(dst.get_class() == RegClass::I32);
-  debug_assert!(srcL.get_class() == RegClass::I32);
-  Inst::BinOp { op: BinOp::CmpLE, dst, srcL, srcR }
-}
-pub fn i_cmp_ge(dst: Reg, srcL: Reg, srcR: RI) -> Inst {
-  debug_assert!(dst.get_class() == RegClass::I32);
-  debug_assert!(srcL.get_class() == RegClass::I32);
-  Inst::BinOp { op: BinOp::CmpGE, dst, srcL, srcR }
-}
-pub fn i_cmp_gt(dst: Reg, srcL: Reg, srcR: RI) -> Inst {
-  debug_assert!(dst.get_class() == RegClass::I32);
-  debug_assert!(srcL.get_class() == RegClass::I32);
-  Inst::BinOp { op: BinOp::CmpGT, dst, srcL, srcR }
-}
-
-// 2-operand versions of i_add and i_sub, for experimentation
-pub fn i_addm(dst: Reg, srcR: RI) -> Inst {
-  debug_assert!(dst.get_class() == RegClass::I32);
-  Inst::BinOpM { op: BinOp::Add, dst, srcR }
-}
-pub fn i_subm(dst: Reg, srcR: RI) -> Inst {
-  debug_assert!(dst.get_class() == RegClass::I32);
-  Inst::BinOpM { op: BinOp::Sub, dst, srcR }
-}
-
-pub fn i_fadd(dst: Reg, srcL: Reg, srcR: Reg) -> Inst {
-  debug_assert!(dst.get_class() == RegClass::F32);
-  debug_assert!(srcL.get_class() == RegClass::F32);
-  debug_assert!(srcR.get_class() == RegClass::F32);
-  Inst::BinOpF { op: BinOpF::FAdd, dst, srcL, srcR }
-}
-pub fn i_fsub(dst: Reg, srcL: Reg, srcR: Reg) -> Inst {
-  debug_assert!(dst.get_class() == RegClass::F32);
-  debug_assert!(srcL.get_class() == RegClass::F32);
-  debug_assert!(srcR.get_class() == RegClass::F32);
-  Inst::BinOpF { op: BinOpF::FSub, dst, srcL, srcR }
-}
-pub fn i_fmul(dst: Reg, srcL: Reg, srcR: Reg) -> Inst {
-  debug_assert!(dst.get_class() == RegClass::F32);
-  debug_assert!(srcL.get_class() == RegClass::F32);
-  debug_assert!(srcR.get_class() == RegClass::F32);
-  Inst::BinOpF { op: BinOpF::FMul, dst, srcL, srcR }
-}
-pub fn i_fdiv(dst: Reg, srcL: Reg, srcR: Reg) -> Inst {
-  debug_assert!(dst.get_class() == RegClass::F32);
-  debug_assert!(srcL.get_class() == RegClass::F32);
-  debug_assert!(srcR.get_class() == RegClass::F32);
-  Inst::BinOpF { op: BinOpF::FDiv, dst, srcL, srcR }
-}
-
-impl fmt::Debug for Inst {
-  fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-    fn ljustify(s: String, w: usize) -> String {
-      if s.len() >= w {
-        s
-      } else {
-        // BEGIN hack
-        let mut need = w - s.len();
-        if need > 5 {
-          need = 5;
-        }
-        let extra = [" ", "  ", "   ", "    ", "     "][need - 1];
-        // END hack
-        s + &extra.to_string()
-      }
-    }
-
-    match self {
-      Inst::Imm { dst, imm } => write!(fmt, "imm     {:?}, {:?}", dst, imm),
-      Inst::ImmF { dst, imm } => write!(fmt, "immf    {:?}, {:?}", dst, imm),
-      Inst::Copy { dst, src } => write!(fmt, "copy    {:?}, {:?}", dst, src),
-      Inst::BinOp { op, dst, srcL, srcR } => write!(
-        fmt,
-        "{} {:?}, {:?}, {:?}",
-        ljustify(op.to_string(), 7),
-        dst,
-        srcL,
-        srcR
-      ),
-      Inst::BinOpM { op, dst, srcR } => write!(
-        fmt,
-        "{} {:?}, {:?}",
-        ljustify(op.to_string() + &"m".to_string(), 7),
-        dst,
-        srcR
-      ),
-      Inst::BinOpF { op, dst, srcL, srcR } => write!(
-        fmt,
-        "{} {:?}, {:?}, {:?}",
-        ljustify(op.to_string(), 7),
-        dst,
-        srcL,
-        srcR
-      ),
-      Inst::Load { dst, addr } => write!(fmt, "load    {:?}, {:?}", dst, addr),
-      Inst::LoadF { dst, addr } => write!(fmt, "loadf   {:?}, {:?}", dst, addr),
-      Inst::Store { addr, src } => write!(fmt, "store   {:?}, {:?}", addr, src),
-      Inst::StoreF { addr, src } => {
-        write!(fmt, "storef  {:?}, {:?}", addr, src)
-      }
-      Inst::Spill { dst, src } => write!(fmt, "SPILL   {:?}, {:?}", dst, src),
-      Inst::SpillF { dst, src } => write!(fmt, "SPILLF  {:?}, {:?}", dst, src),
-      Inst::Reload { dst, src } => write!(fmt, "RELOAD  {:?}, {:?}", dst, src),
-      Inst::ReloadF { dst, src } => write!(fmt, "RELOAD  {:?}, {:?}", dst, src),
-      Inst::Goto { target } => write!(fmt, "goto    {:?}", target),
-      Inst::GotoCTF { cond, targetT, targetF } => write!(
-        fmt,
-        "goto    if {:?} then {:?} else {:?}",
-        cond, targetT, targetF
-      ),
-      Inst::PrintS { str } => {
-        let mut res = "prints '".to_string();
-        for c in str.chars() {
-          res += &(if c == '\n' { "\\n".to_string() } else { c.to_string() });
-        }
-        write!(fmt, "{}'", res)
-      }
-      Inst::PrintI { reg } => write!(fmt, "printi {:?}", reg),
-      Inst::PrintF { reg } => write!(fmt, "printf {:?}", reg),
-      Inst::Finish {} => write!(fmt, "finish"),
-    }
-  }
-}
-
-impl Inst {
-  // Returns a vector of BlockIxs, being those that this insn might jump to.
-  // This might contain duplicates (although it would be pretty strange if
-  // it did). This function should not be applied to non-control-flow
-  // instructions.  The labels are assumed all to be "resolved".
-  pub fn getTargets(&self) -> Vec<BlockIx> {
-    match self {
-      Inst::Goto { target } => vec![target.getBlockIx()],
-      Inst::GotoCTF { cond: _, targetT, targetF } => {
-        vec![targetT.getBlockIx(), targetF.getBlockIx()]
-      }
-      Inst::Finish {} => vec![],
-      _other => panic!("Inst::getTargets: incorrectly applied to: {:?}", self),
-    }
-  }
-
-  // Returns three sets of regs, (def, mod, use), being those def'd
-  // (written), those mod'd (modified) and those use'd (read) by the
-  // instruction, respectively.  Note "use" is sometimes written as "uce"
-  // below since "use" is a Rust reserved word, and similarly "mod" is
-  // written "m0d" (that's a zero, not capital-o).
-  //
-  // Be careful here.  If an instruction really modifies a register -- as is
-  // typical for x86 -- that register needs to be in the |mod| set, and not
-  // in the |def| and |use| sets.  *Any* mistake in describing register uses
-  // here will almost certainly lead to incorrect register allocations.
-  //
-  // Also the following must hold: the union of |def| and |use| must be
-  // disjoint from |mod|.
-  pub fn get_reg_usage(&self) -> (Set<Reg>, Set<Reg>, Set<Reg>) {
-    let mut def = Set::<Reg>::empty();
-    let mut m0d = Set::<Reg>::empty();
-    let mut uce = Set::<Reg>::empty();
-    match self {
-      Inst::Imm { dst, imm: _ } => {
-        def.insert(*dst);
-      }
-      Inst::Copy { dst, src } => {
-        def.insert(*dst);
-        uce.insert(*src);
-      }
-      Inst::BinOp { op: _, dst, srcL, srcR } => {
-        def.insert(*dst);
-        uce.insert(*srcL);
-        srcR.addRegReadsTo(&mut uce);
-      }
-      Inst::BinOpM { op: _, dst, srcR } => {
-        m0d.insert(*dst);
-        srcR.addRegReadsTo(&mut uce);
-      }
-      Inst::Store { addr, src } => {
-        addr.addRegReadsTo(&mut uce);
-        uce.insert(*src);
-      }
-      Inst::Load { dst, addr } => {
-        def.insert(*dst);
-        addr.addRegReadsTo(&mut uce);
-      }
-      Inst::Goto { .. } => {}
-      Inst::GotoCTF { cond, targetT: _, targetF: _ } => {
-        uce.insert(*cond);
-      }
-      Inst::PrintS { .. } => {}
-      Inst::PrintI { reg } => {
-        uce.insert(*reg);
-      }
-      Inst::Finish {} => {}
-      _other => panic!("Inst::get_reg_usage: unhandled: {:?}", self),
-    }
-    // Failure of either of these is serious and should be investigated.
-    debug_assert!(!def.intersects(&m0d));
-    debug_assert!(!uce.intersects(&m0d));
-    (def, m0d, uce)
-  }
-
-  // Apply the specified VirtualReg->RealReg mappings to the instruction,
-  // thusly:
-  // * For registers mentioned in a read role, apply mapU.
-  // * For registers mentioned in a write role, apply mapD.
-  // * For registers mentioned in a modify role, mapU and mapD *must* agree
-  //   (if not, our caller is buggy).  So apply either map to that register.
-  pub fn mapRegs_D_U(
-    &mut self, mapD: &Map<VirtualReg, RealReg>, mapU: &Map<VirtualReg, RealReg>,
-  ) {
-    let mut ok = true;
-    match self {
-      Inst::Imm { dst, imm: _ } => {
-        dst.apply_D_or_U(mapD);
-      }
-      Inst::Copy { dst, src } => {
-        dst.apply_D_or_U(mapD);
-        src.apply_D_or_U(mapU);
-      }
-      Inst::BinOp { op: _, dst, srcL, srcR } => {
-        dst.apply_D_or_U(mapD);
-        srcL.apply_D_or_U(mapU);
-        srcR.apply_D_or_U(mapU);
-      }
-      Inst::BinOpM { op: _, dst, srcR } => {
-        dst.apply_M(mapD, mapU);
-        srcR.apply_D_or_U(mapU);
-      }
-      Inst::Store { addr, src } => {
-        addr.apply_D_or_U(mapU);
-        src.apply_D_or_U(mapU);
-      }
-      Inst::Load { dst, addr } => {
-        dst.apply_D_or_U(mapD);
-        addr.apply_D_or_U(mapU);
-      }
-      Inst::Goto { .. } => {}
-      Inst::GotoCTF { cond, targetT: _, targetF: _ } => {
-        cond.apply_D_or_U(mapU);
-      }
-      Inst::PrintS { .. } => {}
-      Inst::PrintI { reg } => {
-        reg.apply_D_or_U(mapU);
-      }
-      Inst::Finish {} => {}
-      _ => {
-        ok = false;
-      }
-    }
-    if !ok {
-      panic!("Inst::mapRegs_D_U: unhandled: {:?}", self);
-    }
-  }
-}
-
-fn is_control_flow_insn(insn: &Inst) -> bool {
-  match insn {
-    Inst::Goto { .. } | Inst::GotoCTF { .. } | Inst::Finish {} => true,
-    _ => false,
-  }
-}
-
-pub fn is_goto_insn(insn: &Inst) -> Option<Label> {
-  match insn {
-    Inst::Goto { target } => Some(target.clone()),
-    _ => None,
-  }
-}
-
-pub fn remapControlFlowTarget(insn: &mut Inst, from: &String, to: &String) {
-  match insn {
-    Inst::Goto { ref mut target } => {
-      target.remapControlFlow(from, to);
-    }
-    Inst::GotoCTF { cond: _, ref mut targetT, ref mut targetF } => {
-      targetT.remapControlFlow(from, to);
-      targetF.remapControlFlow(from, to);
-    }
-    _ => (),
-  }
-}
-
-//=============================================================================
-// Definition of Block and Func, and printing thereof.
-
-pub struct Block {
-  pub name: String,
-  pub start: InstIx,
-  pub len: u32,
-  pub estFreq: u16, // Estimated execution frequency
-}
-pub fn mkBlock(name: String, start: InstIx, len: u32) -> Block {
-  Block { name, start, len, estFreq: 1 }
-}
-impl Clone for Block {
-  // This is only needed for debug printing.
-  fn clone(&self) -> Self {
-    Block {
-      name: self.name.clone(),
-      start: self.start,
-      len: self.len,
-      estFreq: self.estFreq,
-    }
-  }
-}
-impl Block {
-  fn containsInstIx(&self, iix: InstIx) -> bool {
-    iix.get() >= self.start.get() && iix.get() < self.start.get() + self.len
-  }
-}
-
-pub struct Func {
-  pub name: String,
-  pub entry: Label,
-  pub nVirtualRegs: u32,
-  pub insns: TypedIxVec<InstIx, Inst>, // indexed by InstIx
-  pub blocks: TypedIxVec<BlockIx, Block>, // indexed by BlockIx
-                                       // Note that |blocks| must be in order of increasing |Block::start|
-                                       // fields.  Code that wants to traverse the blocks in some other order
-                                       // must represent the ordering some other way; rearranging Func::blocks is
-                                       // not allowed.
-}
-impl Clone for Func {
-  // This is only needed for debug printing.
-  fn clone(&self) -> Self {
-    Func {
-      name: self.name.clone(),
-      entry: self.entry.clone(),
-      nVirtualRegs: self.nVirtualRegs,
-      insns: self.insns.clone(),
-      blocks: self.blocks.clone(),
-    }
-  }
-}
-
-// Find a block Ix for a block name
-fn lookup(blocks: &TypedIxVec<BlockIx, Block>, name: String) -> BlockIx {
-  let mut bix = 0;
-  for b in blocks.iter() {
-    if b.name == name {
-      return mkBlockIx(bix);
-    }
-    bix += 1;
-  }
-  panic!("Func::lookup: can't resolve label name '{}'", name);
-}
-
-impl Func {
-  pub fn new<'a>(name: &'a str, entry: &'a str) -> Self {
-    Func {
-      name: name.to_string(),
-      entry: Label::Unresolved { name: entry.to_string() },
-      nVirtualRegs: 0,
-      insns: TypedIxVec::<InstIx, Inst>::new(),
-      blocks: TypedIxVec::<BlockIx, Block>::new(),
-    }
-  }
-
-  pub fn print(&self, who: &str) {
-    println!("");
-    println!("Func {}: name='{}' entry='{:?}' {{", who, self.name, self.entry);
-    let mut ix = 0;
-    for b in self.blocks.iter() {
-      if ix > 0 {
-        println!("");
-      }
-      println!("  {:?}:{}", mkBlockIx(ix), b.name);
-      for i in b.start.get()..b.start.get() + b.len {
-        let ixI = mkInstIx(i);
-        println!("      {:<3?}   {:?}", ixI, self.insns[ixI]);
-      }
-      ix += 1;
-    }
-    println!("}}");
-  }
-
-  // Get a new VirtualReg name
-  pub fn newVirtualReg(&mut self, rc: RegClass) -> Reg {
-    let v = mkVirtualReg(rc, self.nVirtualRegs);
-    self.nVirtualRegs += 1;
-    v
-  }
-
-  // Add a block to the Func
-  pub fn block<'a>(
-    &mut self, name: &'a str, mut insns: TypedIxVec<InstIx, Inst>,
-  ) {
-    let start = self.insns.len();
-    let len = insns.len() as u32;
-    self.insns.append(&mut insns);
-    let b = mkBlock(name.to_string(), mkInstIx(start), len);
-    self.blocks.push(b);
-  }
-
-  // All blocks have been added.  Resolve labels and we're good to go.
-  /* .finish(): check
-        - all blocks nonempty
-        - all blocks end in i_finish, i_goto or i_goto_ctf
-        - no blocks have those insns before the end
-        - blocks are in increasing order of ::start fields
-        - all referenced blocks actually exist
-        - convert references to block numbers
-  */
-  pub fn finish(&mut self) {
-    for bix in mkBlockIx(0).dotdot(mkBlockIx(self.blocks.len())) {
-      let b = &self.blocks[bix];
-      if b.len == 0 {
-        panic!("Func::done: a block is empty");
-      }
-      if bix > mkBlockIx(0)
-        && self.blocks[bix.minus(1)].start >= self.blocks[bix].start
-      {
-        panic!("Func: blocks are not in increasing order of InstIx");
-      }
-      for i in 0..b.len {
-        let iix = b.start.plus(i);
-        if i == b.len - 1 && !is_control_flow_insn(&self.insns[iix]) {
-          panic!("Func: block must end in control flow insn");
-        }
-        if i != b.len - 1 && is_control_flow_insn(&self.insns[iix]) {
-          panic!("Func: block contains control flow insn not at end");
-        }
-      }
-    }
-
-    // Resolve all labels
-    let blocks = &self.blocks;
-    for i in self.insns.iter_mut() {
-      resolveInst(i, |name| lookup(blocks, name));
-    }
-    resolveLabel(&mut self.entry, |name| lookup(blocks, name));
-  }
-}
-
-fn resolveLabel<F>(label: &mut Label, lookup: F)
-where
-  F: Fn(String) -> BlockIx,
-{
-  let resolved = match label {
-    Label::Unresolved { name } => {
-      Label::Resolved { name: name.clone(), bix: lookup(name.clone()) }
-    }
-    Label::Resolved { .. } => panic!("resolveLabel: is already resolved!"),
-  };
-  *label = resolved;
-}
-
-fn resolveInst<F>(insn: &mut Inst, lookup: F)
-where
-  F: Copy + Fn(String) -> BlockIx,
-{
-  match insn {
-    Inst::Goto { ref mut target } => resolveLabel(target, lookup),
-    Inst::GotoCTF { cond: _, ref mut targetT, ref mut targetF } => {
-      resolveLabel(targetT, lookup);
-      resolveLabel(targetF, lookup);
-    }
-    _ => (),
   }
 }
 
@@ -1830,6 +974,10 @@ impl fmt::Debug for RangeFrag {
     )
   }
 }
+
+// TODO: convert to use Function trait/interface instead.
+use crate::tests::Block;
+
 pub fn mkRangeFrag(
   blocks: &TypedIxVec<BlockIx, Block>, bix: BlockIx, first: InstPoint,
   last: InstPoint, count: u16,

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -158,7 +158,7 @@ pub struct RegAllocResult<F: Function> {
   pub clobbered_registers: Set<RealReg>,
 
   /// How many spill slots were used?
-  pub num_spill_slots: SpillSlot,
+  pub num_spill_slots: u32,
 }
 
 /// Allocate registers for a function's code, given a universe of real registers that we are

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,0 +1,151 @@
+/* -*- Mode: Rust; tab-width: 8; indent-tabs-mode: nil; rust-indent-offset: 2 -*-
+ * vim: set ts=8 sts=2 et sw=2 tw=80:
+*/
+#![allow(non_snake_case)]
+#![allow(unused_imports)]
+#![allow(non_camel_case_types)]
+
+// This is the top level interface for the regalloc library.
+
+// Stuff that is defined by the library
+
+// Sets and maps of things.  We can refine these later; but for now the
+// interface needs some way to speak about them, so let's use the
+// library-provided versions.
+
+pub use crate::data_structures::Map;
+pub use crate::data_structures::Set;
+
+// Register classes
+
+pub use crate::data_structures::RegClass;
+
+// Registers, both real and virtual, and ways to create them
+
+pub use crate::data_structures::mkRealReg;
+pub use crate::data_structures::mkVirtualReg;
+pub use crate::data_structures::Reg;
+
+pub use crate::data_structures::RealReg;
+pub use crate::data_structures::VirtualReg;
+
+// Spill slots
+
+pub use crate::data_structures::SpillSlot;
+
+// The real reg universe
+
+pub use crate::data_structures::RealRegUniverse;
+
+/// Register uses for a given instruction.
+pub struct InstRegUses {
+  used: Set<Reg>,    // registers that are read.
+  defined: Set<Reg>, // registers that are written.
+  modified: Set<Reg>, // registers that are modified.
+                     // Note that `modified` is distinct from just `used`+`defined` because the
+                     // vreg must live in the same real reg both before and after the
+                     // instruction.
+}
+
+// TypedIxVector, so that the interface can speak about vectors of blocks and
+// instructions.
+
+pub use crate::data_structures::TypedIxVec;
+pub use crate::data_structures::{BlockIx, InstIx, MyRange};
+
+/// A trait defined by the regalloc client to provide access to its machine-instruction / CFG
+/// representation.
+pub trait Function {
+  /// Regalloc is parameterized on F: Function and so can use the projected
+  /// type F::Inst.
+  type Inst: Clone;
+
+  // -------------
+  // CFG traversal
+  // -------------
+
+  /// Allow access to the underlying vector of instructions.
+  fn insns(&self) -> &[Self::Inst];
+
+  /// Allow iteration over basic blocks (in instruction order).
+  fn blocks(&self) -> MyRange<BlockIx>;
+
+  /// Provide the range of instruction indices contained in each block.
+  fn block_insns(&self, block: BlockIx) -> MyRange<InstIx>;
+
+  /// Get CFG successors: indexed by block, provide a list of successor blocks.
+  fn block_succs(&self) -> TypedIxVec<BlockIx, Vec<BlockIx>>;
+
+  /// Provide the defined, used, and modified registers for an instruction.
+  fn get_regs(&self, insn: &Self::Inst) -> InstRegUses;
+
+  /// Map each register slot through a virt -> phys mapping indexed
+  /// by virtual register. The two separate maps provide the
+  /// mapping to use for uses (which semantically occur just prior
+  /// to the instruction's effect) and defs (which semantically occur
+  /// just after the instruction's effect). Regs that were "modified"
+  /// can use either map; the vreg should be the same in both.
+  fn map_regs(
+    &self, insn: &mut Self::Inst, pre_map: &Map<VirtualReg, RealReg>,
+    post_map: &Map<VirtualReg, RealReg>,
+  );
+
+  /// Allow the regalloc to query whether this is a move.
+  fn is_move(&self, insn: &Self::Inst) -> Option<(Reg, Reg)>;
+
+  /// How many logical spill slots does the given regclass require?  E.g., on a
+  /// 64-bit machine, spill slots may nominally be 64-bit words, but a 128-bit
+  /// vector value will require two slots.  The regalloc will always align on
+  /// this size.
+  fn get_spillslot_size(&self, regclass: RegClass) -> SpillSlot;
+
+  /// Generate a spill instruction for insertion into the instruction sequence.
+  fn gen_spill(&self, from_reg: RealReg, to_slot: SpillSlot) -> Self::Inst;
+
+  /// Generate a reload instruction for insertion into the instruction sequence.
+  fn gen_reload(&self, from_slot: SpillSlot, to_reg: RealReg) -> Self::Inst;
+
+  /// Generate a register-to-register move for insertion into the instruction sequence.
+  fn gen_move(&self, from_reg: RealReg, to_reg: RealReg) -> Self::Inst;
+
+  /// Try to alter an existing instruction to use a value directly in a
+  /// spillslot (accessing memory directly) instead of the given register. May
+  /// be useful on ISAs that have mem/reg ops, like x86.
+  ///
+  /// Note that this is not *quite* just fusing a load with the op; if the
+  /// value is def'd or modified, it should be written back to the spill slot
+  /// as well. In other words, it is just using the spillslot as if it were a
+  /// real register, for reads and/or writes.
+  fn maybe_direct_reload(
+    &self, insn: &Self::Inst, reg: VirtualReg, slot: SpillSlot,
+  ) -> Option<Self::Inst>;
+}
+
+/// The result of register allocation.  Note that allocation can fail!
+pub struct RegAllocResult<F: Function> {
+  /// A new sequence of instructions with all register slots filled with real registers, and
+  /// spills/fills/moves possibly inserted (and unneeded moves elided).
+  pub insns: Vec<F::Inst>,
+
+  /// Basic-block start indices for the new instruction list, indexed by the original basic block
+  /// indices. May be used by the client to, e.g., remap branch targets appropriately.
+  pub target_map: Map<BlockIx, InstIx>,
+
+  /// Which real registers were overwritten? This will contain all real regs that appear as defs or
+  /// modifies in register slots of the output instruction list.
+  pub clobbered_registers: Set<RealReg>,
+
+  /// How many spill slots were used?
+  pub num_spill_slots: SpillSlot,
+}
+
+/// Allocate registers for a function's code, given a universe of real registers that we are
+/// allowed to use. Allocate may succeed, returning a `RegAllocResult` with the new instruction
+/// sequence, or it may fail, returning an error string.
+///
+/// TODO: better error type? Are there a few canonical errors we return (out of regs, ...)?
+pub fn allocate_registers<F: Function>(
+  func: &F, rreg_universe: &RealRegUniverse,
+) -> Result<RegAllocResult<F>, String> {
+  Err("Unimplemented".into())
+}

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -67,8 +67,14 @@ pub trait Function {
   /// Allow access to the underlying vector of instructions.
   fn insns(&self) -> &[Self::Inst];
 
+  /// Get an instruction with a type-safe InstIx index.
+  fn get_insn(&self, insn: InstIx) -> &Self::Inst;
+
   /// Allow iteration over basic blocks (in instruction order).
   fn blocks(&self) -> MyRange<BlockIx>;
+
+  /// Get the index of the entry block.
+  fn entry_block(&self) -> BlockIx;
 
   /// Provide the range of instruction indices contained in each block.
   fn block_insns(&self, block: BlockIx) -> MyRange<InstIx>;

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -112,7 +112,7 @@ pub trait Function {
     post_map: &Map<VirtualReg, RealReg>,
   );
 
-  /// Allow the regalloc to query whether this is a move.
+  /// Allow the regalloc to query whether this is a move. Returns (dst, src).
   fn is_move(&self, insn: &Self::Inst) -> Option<(Reg, Reg)>;
 
   /// How many logical spill slots does the given regclass require?  E.g., on a
@@ -122,13 +122,13 @@ pub trait Function {
   fn get_spillslot_size(&self, regclass: RegClass) -> u32;
 
   /// Generate a spill instruction for insertion into the instruction sequence.
-  fn gen_spill(&self, from_reg: RealReg, to_slot: SpillSlot) -> Self::Inst;
+  fn gen_spill(&self, to_slot: SpillSlot, from_reg: RealReg) -> Self::Inst;
 
   /// Generate a reload instruction for insertion into the instruction sequence.
-  fn gen_reload(&self, from_slot: SpillSlot, to_reg: RealReg) -> Self::Inst;
+  fn gen_reload(&self, to_reg: RealReg, from_slot: SpillSlot) -> Self::Inst;
 
   /// Generate a register-to-register move for insertion into the instruction sequence.
-  fn gen_move(&self, from_reg: RealReg, to_reg: RealReg) -> Self::Inst;
+  fn gen_move(&self, to_reg: RealReg, from_reg: RealReg) -> Self::Inst;
 
   /// Try to alter an existing instruction to use a value directly in a
   /// spillslot (accessing memory directly) instead of the given register. May
@@ -151,7 +151,7 @@ pub struct RegAllocResult<F: Function> {
 
   /// Basic-block start indices for the new instruction list, indexed by the original basic block
   /// indices. May be used by the client to, e.g., remap branch targets appropriately.
-  pub target_map: Map<BlockIx, InstIx>,
+  pub target_map: TypedIxVec<BlockIx, InstIx>,
 
   /// Which real registers were overwritten? This will contain all real regs that appear as defs or
   /// modifies in register slots of the output instruction list.

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -59,7 +59,7 @@ pub use crate::data_structures::{mkInstIx, BlockIx, InstIx, MyRange};
 pub trait Function {
   /// Regalloc is parameterized on F: Function and so can use the projected
   /// type F::Inst.
-  type Inst: Clone + std::fmt::Debug;
+  type Inst: Clone;
 
   // -------------
   // CFG traversal

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -39,12 +39,12 @@ pub use crate::data_structures::RealRegUniverse;
 
 /// Register uses for a given instruction.
 pub struct InstRegUses {
-  used: Set<Reg>,    // registers that are read.
-  defined: Set<Reg>, // registers that are written.
-  modified: Set<Reg>, // registers that are modified.
-                     // Note that `modified` is distinct from just `used`+`defined` because the
-                     // vreg must live in the same real reg both before and after the
-                     // instruction.
+  pub used: Set<Reg>,    // registers that are read.
+  pub defined: Set<Reg>, // registers that are written.
+  pub modified: Set<Reg>, // registers that are modified.
+                          // Note that `modified` is distinct from just `used`+`defined` because
+                          // the vreg must live in the same real reg both before and after the
+                          // instruction.
 }
 
 // TypedIxVector, so that the interface can speak about vectors of blocks and
@@ -73,8 +73,8 @@ pub trait Function {
   /// Provide the range of instruction indices contained in each block.
   fn block_insns(&self, block: BlockIx) -> MyRange<InstIx>;
 
-  /// Get CFG successors: indexed by block, provide a list of successor blocks.
-  fn block_succs(&self) -> TypedIxVec<BlockIx, Vec<BlockIx>>;
+  /// Get CFG successors for a given block.
+  fn block_succs(&self, block: BlockIx) -> Vec<BlockIx>;
 
   /// Provide the defined, used, and modified registers for an instruction.
   fn get_regs(&self, insn: &Self::Inst) -> InstRegUses;

--- a/src/linear_scan.rs
+++ b/src/linear_scan.rs
@@ -5,14 +5,15 @@
 
 use crate::analysis::run_analysis;
 use crate::data_structures::{
-  i_reload, i_spill, mkBlockIx, mkInstIx, mkInstPoint, mkRangeFrag,
-  mkRangeFragIx, mkRealReg, mkSpillSlot, mkVirtualRangeIx, Block, BlockIx,
-  Func, Inst, InstIx, InstPoint, InstPoint_Def, InstPoint_Reload,
-  InstPoint_Spill, InstPoint_Use, Map, Point, RangeFrag, RangeFragIx,
-  RangeFragKind, RealRange, RealReg, RealRegUniverse, Reg, Set,
+  mkBlockIx, mkInstIx, mkInstPoint, mkRangeFrag, mkRangeFragIx, mkRealReg,
+  mkSpillSlot, mkVirtualRangeIx, BlockIx, InstIx, InstPoint, InstPoint_Def,
+  InstPoint_Reload, InstPoint_Spill, InstPoint_Use, Map, Point, RangeFrag,
+  RangeFragIx, RangeFragKind, RealRange, RealReg, RealRegUniverse, Reg, Set,
   SortedRangeFragIxs, SpillSlot, TypedIxVec, VirtualRange, VirtualRangeIx,
   VirtualReg,
 };
+
+use crate::tests::{i_reload, i_spill, Block, Func, Inst};
 
 // Allocator top level.  |func| is modified so that, when this function
 // returns, it will contain no VirtualReg uses.  Allocation can fail if there

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,7 @@ mod backtracking;
 mod data_structures;
 mod linear_scan;
 mod tests;
+mod interface;
 
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,9 +54,9 @@ Performance:
 mod analysis;
 mod backtracking;
 mod data_structures;
+mod interface;
 mod linear_scan;
 mod tests;
-mod interface;
 
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
@@ -73,9 +73,10 @@ use std::ops::Range;
 use std::slice::{Iter, IterMut};
 use std::{fs, io};
 
+use tests::{make_universe, BinOp, Block, Func, Inst, Label, AM, RI};
+
 use data_structures::{
-  make_universe, BinOp, Block, BlockIx, Func, Inst, InstIx, Label, RealReg,
-  RealRegUniverse, Reg, SpillSlot, VirtualReg, AM, RI,
+  BlockIx, InstIx, RealReg, RealRegUniverse, Reg, SpillSlot, VirtualReg,
 };
 
 //=============================================================================

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1116,15 +1116,21 @@ impl interface::Function for Func {
     &self.insns.elems()
   }
 
+  fn get_insn(&self, iix: InstIx) -> &Inst {
+    &self.insns[iix]
+  }
+
+  fn entry_block(&self) -> BlockIx {
+    mkBlockIx(0)
+  }
+
   fn blocks(&self) -> MyRange<BlockIx> {
     self.blocks.range()
   }
 
   /// Provide the range of instruction indices contained in each block.
   fn block_insns(&self, block: BlockIx) -> MyRange<InstIx> {
-    let start = self.blocks[block].start;
-    let end = start.plus(self.blocks[block].len);
-    MyRange::new(start, end)
+    MyRange::new(self.blocks[block].start, self.blocks[block].len as usize)
   }
 
   /// Get CFG successors: indexed by block, provide a list of successor blocks.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -830,7 +830,7 @@ impl Func {
     self.insns = TypedIxVec::fromVec(result.insns);
     for bix in self.blocks.range() {
       let block = &mut self.blocks[bix];
-      block.start = *result.target_map.get(&bix).unwrap();
+      block.start = result.target_map[bix];
     }
   }
 }
@@ -1189,7 +1189,7 @@ impl interface::Function for Func {
   /// Allow the regalloc to query whether this is a move.
   fn is_move(&self, insn: &Self::Inst) -> Option<(Reg, Reg)> {
     match insn {
-      &Inst::Copy { dst, src } => Some((src, dst)),
+      &Inst::Copy { dst, src } => Some((dst, src)),
       _ => None,
     }
   }
@@ -1204,7 +1204,7 @@ impl interface::Function for Func {
   }
 
   /// Generate a spill instruction for insertion into the instruction sequence.
-  fn gen_spill(&self, from_reg: RealReg, to_slot: SpillSlot) -> Self::Inst {
+  fn gen_spill(&self, to_slot: SpillSlot, from_reg: RealReg) -> Self::Inst {
     match from_reg.get_class() {
       RegClass::I32 => Inst::Spill { dst: to_slot, src: from_reg },
       RegClass::F32 => Inst::SpillF { dst: to_slot, src: from_reg },
@@ -1213,7 +1213,7 @@ impl interface::Function for Func {
   }
 
   /// Generate a reload instruction for insertion into the instruction sequence.
-  fn gen_reload(&self, from_slot: SpillSlot, to_reg: RealReg) -> Self::Inst {
+  fn gen_reload(&self, to_reg: RealReg, from_slot: SpillSlot) -> Self::Inst {
     match to_reg.get_class() {
       RegClass::I32 => Inst::Reload { src: from_slot, dst: to_reg },
       RegClass::F32 => Inst::ReloadF { src: from_slot, dst: to_reg },
@@ -1222,7 +1222,7 @@ impl interface::Function for Func {
   }
 
   /// Generate a register-to-register move for insertion into the instruction sequence.
-  fn gen_move(&self, from_reg: RealReg, to_reg: RealReg) -> Self::Inst {
+  fn gen_move(&self, to_reg: RealReg, from_reg: RealReg) -> Self::Inst {
     Inst::Copy { src: from_reg.to_reg(), dst: to_reg.to_reg() }
   }
 


### PR DESCRIPTION
This PR (i) adds the interface defined in the design doc we merged in #1, (ii) moves the test-ISA types (`Inst`, `Block`, and `Func`) to the `tests` submodule, (iii) implements the `Function` trait on `Func`, thus serving as the first client of the generic API, and (iv) modifies the backtracking regalloc to operate through the trait instead of directly on the test ISA.

The linear-scan regalloc is still TODO, and there are probably some opportunities for cleanup, but I tried to make the translation as straightforward as I could. In the course of doing so, I played with the ergonomics a bit on the index/range type stuff; happy to iterate on that if it's not to taste.

@julian-seward1 or @bnjbvr, would you mind reviewing? Thanks!