### PR TITLE
Exposed crate as a library, with test-runner in separate binary.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,8 @@ name = "minira"
 version = "0.1.0"
 authors = ["Julian Seward <jseward@acm.org>"]
 edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+type = "lib"
+bin = ["minira"]
 
 [dependencies]
 rustc-hash = "1.0.1"

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -161,15 +161,15 @@ impl<'a, T> Iterator for SetIter<'a, T> {
 //   for ent in startEnt .. endPlus1Ent {
 //   }
 
-trait Zero {
+pub trait Zero {
   fn zero() -> Self;
 }
 
-trait PlusOne {
+pub trait PlusOne {
   fn plus_one(&self) -> Self;
 }
 
-trait PlusN: PlusOne {
+pub trait PlusN: PlusOne {
   fn plus_n(&self, n: usize) -> Self;
 }
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -31,9 +31,11 @@ pub use crate::data_structures::Reg;
 pub use crate::data_structures::RealReg;
 pub use crate::data_structures::VirtualReg;
 
+pub use crate::data_structures::NUM_REG_CLASSES;
+
 // Spill slots
 
-pub use crate::data_structures::SpillSlot;
+pub use crate::data_structures::{mkSpillSlot, SpillSlot};
 
 // The real reg universe
 
@@ -54,7 +56,9 @@ pub struct InstRegUses {
 // instructions.
 
 pub use crate::data_structures::TypedIxVec;
-pub use crate::data_structures::{mkInstIx, BlockIx, InstIx, MyRange};
+pub use crate::data_structures::{
+  mkBlockIx, mkInstIx, BlockIx, InstIx, MyRange,
+};
 
 /// A trait defined by the regalloc client to provide access to its machine-instruction / CFG
 /// representation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,13 @@
+//! Main file / top-level module for minira library.
+
+#![allow(non_snake_case)]
+#![allow(unused_imports)]
+#![allow(non_camel_case_types)]
+
+pub mod analysis;
+pub mod backtracking;
+pub mod data_structures;
+pub mod linear_scan;
+pub mod tests;
+
+pub mod interface;

--- a/src/linear_scan.rs
+++ b/src/linear_scan.rs
@@ -12,17 +12,16 @@ use crate::data_structures::{
   SortedRangeFragIxs, SpillSlot, TypedIxVec, VirtualRange, VirtualRangeIx,
   VirtualReg,
 };
-
-use crate::tests::{i_reload, i_spill, Block, Func, Inst};
+use crate::interface::{Function, RegAllocResult};
 
 // Allocator top level.  |func| is modified so that, when this function
 // returns, it will contain no VirtualReg uses.  Allocation can fail if there
 // are insufficient registers to even generate spill/reload code, or if the
 // function appears to have any undefined VirtualReg/RealReg uses.
 #[inline(never)]
-pub fn alloc_main(
-  func: &mut Func, reg_universe: &RealRegUniverse,
-) -> Result<(), String> {
+pub fn alloc_main<F: Function>(
+  func: &mut F, reg_universe: &RealRegUniverse,
+) -> Result<RegAllocResult<F>, String> {
   let (rlr_env, mut vlr_env, mut frag_env) = run_analysis(func)?;
 
   unimplemented!("linear scan");

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,8 +4,7 @@
 /// As part of this set of test cases, we define a mini IR and implement the `Function` trait for
 /// it so that we can use the regalloc public interface.
 use crate::interface;
-
-use crate::data_structures::{
+use crate::interface::{
   mkBlockIx, mkInstIx, mkRealReg, mkSpillSlot, mkVirtualReg, BlockIx, InstIx,
   Map, MyRange, RealReg, RealRegUniverse, Reg, RegClass, Set, SpillSlot,
   TypedIxVec, VirtualReg, NUM_REG_CLASSES,
@@ -235,7 +234,7 @@ impl BinOp {
 }
 
 #[derive(Copy, Clone)]
-enum BinOpF {
+pub enum BinOpF {
   FAdd,
   FSub,
   FMul,


### PR DESCRIPTION
Also made a few traits public to avoid errors when using API from another crate.

This change allows the crate to be pulled into a Cranelift build as a
dependency.